### PR TITLE
Add group to kinds list

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 fioletoven
+Copyright (c) 2024 Piotr Frankowski
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/app/app.rs
+++ b/src/app/app.rs
@@ -107,7 +107,7 @@ impl App {
 
     /// Process TUI event
     fn process_event(&mut self, event: TuiEvent) -> Result<ResponseEvent> {
-        let _ = match self.page.process_event(event) {
+        match self.page.process_event(event) {
             ResponseEvent::ExitApplication => return Ok(ResponseEvent::ExitApplication),
             ResponseEvent::Change(kind, namespace) => self.change(kind, namespace)?,
             ResponseEvent::ChangeKind(kind) => self.change_kind(kind, None)?,
@@ -122,14 +122,13 @@ impl App {
 
     /// Changes observed resources namespace and kind
     fn change(&mut self, kind: String, namespace: String) -> Result<(), BgObserverError> {
-        let scope;
-        if namespace == ALL_NAMESPACES {
+        let scope = if namespace == ALL_NAMESPACES {
             self.page.set_namespace(namespace, ViewType::Full);
-            scope = self.worker.restart(kind, None)?;
+            self.worker.restart(kind, None)?
         } else {
             self.page.set_namespace(namespace.clone(), ViewType::Compact);
-            scope = self.worker.restart(kind, Some(namespace))?;
-        }
+            self.worker.restart(kind, Some(namespace))?
+        };
 
         self.set_page_view(scope);
 

--- a/src/app/commands/executor.rs
+++ b/src/app/commands/executor.rs
@@ -9,6 +9,7 @@ use crate::{app::utils::wait_for_task, kubernetes::client::KubernetesClient};
 use super::Command;
 
 /// Background commands executor
+#[derive(Default)]
 pub struct BgExecutor {
     task: Option<JoinHandle<()>>,
     cancellation_token: Option<CancellationToken>,
@@ -16,15 +17,6 @@ pub struct BgExecutor {
 }
 
 impl BgExecutor {
-    /// Creates new [`BgExecutor`] instance
-    pub fn new() -> Self {
-        BgExecutor {
-            task: None,
-            cancellation_token: None,
-            commands_tx: None,
-        }
-    }
-
     /// Starts background task for commands execution
     pub fn start(&mut self, client: &KubernetesClient) {
         if self.cancellation_token.is_some() {

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -28,7 +28,7 @@ pub enum ConfigError {
 }
 
 /// Application configuration
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Default)]
 pub struct Config {
     pub theme: Theme,
 }
@@ -72,12 +72,6 @@ impl Config {
         }
 
         Ok(())
-    }
-}
-
-impl Default for Config {
-    fn default() -> Self {
-        Self { theme: Theme::default() }
     }
 }
 

--- a/src/app/data.rs
+++ b/src/app/data.rs
@@ -12,6 +12,7 @@ pub struct ResourcesInfo {
     pub version: String,
     pub kind: String,
     pub kind_plural: String,
+    pub group: String,
     pub scope: Scope,
     pub count: usize,
 }
@@ -24,6 +25,7 @@ impl Default for ResourcesInfo {
             version: Default::default(),
             kind: Default::default(),
             kind_plural: Default::default(),
+            group: Default::default(),
             scope: Scope::Cluster,
             count: Default::default(),
         }

--- a/src/app/discovery.rs
+++ b/src/app/discovery.rs
@@ -27,11 +27,10 @@ pub struct BgDiscovery {
     has_error: Arc<AtomicBool>,
 }
 
-impl BgDiscovery {
-    /// Creates new [`BgDiscovery`] instance
-    pub fn new() -> Self {
+impl Default for BgDiscovery {
+    fn default() -> Self {
         let (context_tx, context_rx) = mpsc::unbounded_channel();
-        BgDiscovery {
+        Self {
             task: None,
             cancellation_token: None,
             context_tx,
@@ -39,7 +38,9 @@ impl BgDiscovery {
             has_error: Arc::new(AtomicBool::new(false)),
         }
     }
+}
 
+impl BgDiscovery {
     /// Starts new [`BgDiscovery`] task
     pub fn start(&mut self, client: &KubernetesClient) {
         let cancellation_token = CancellationToken::new();
@@ -115,5 +116,5 @@ impl Drop for BgDiscovery {
 /// Converts [`Discovery`] to vector of [`ApiResource`] and [`ApiCapabilities`]
 #[inline]
 fn convert_to_vector(discovery: &Discovery) -> Vec<(ApiResource, ApiCapabilities)> {
-    discovery.groups().map(|g| g.resources_by_stability()).flatten().collect()
+    discovery.groups().flat_map(|g| g.resources_by_stability()).collect()
 }

--- a/src/app/discovery.rs
+++ b/src/app/discovery.rs
@@ -1,6 +1,5 @@
 use kube::{api::ApiResource, discovery::ApiCapabilities, Discovery};
 use std::{
-    collections::HashSet,
     sync::{
         atomic::{AtomicBool, Ordering},
         Arc,
@@ -113,17 +112,8 @@ impl Drop for BgDiscovery {
     }
 }
 
+/// Converts [`Discovery`] to vector of [`ApiResource`] and [`ApiCapabilities`]
+#[inline]
 fn convert_to_vector(discovery: &Discovery) -> Vec<(ApiResource, ApiCapabilities)> {
-    let mut result = Vec::new();
-
-    for group in discovery.groups() {
-        result.append(&mut group.resources_by_stability());
-    }
-
-    // remove duplicates, leaving kinds with the smallest groups
-    result.sort_by(|a, b| a.0.group.cmp(&b.0.group));
-    let mut hs = HashSet::with_capacity(result.len());
-    result.retain(|(ar, _)| hs.insert(ar.plural.clone()));
-
-    result
+    discovery.groups().map(|g| g.resources_by_stability()).flatten().collect()
 }

--- a/src/app/lists/filterable_list.rs
+++ b/src/app/lists/filterable_list.rs
@@ -177,7 +177,7 @@ impl<'a, T> Iterator for FilterableListIterator<'a, T> {
 
     fn next(&mut self) -> Option<&'a T> {
         if let Some(list) = &self.list.filtered {
-            if list.len() == 0 || self.index >= list.len() || list[self.index] >= self.list.items.len() {
+            if list.is_empty() || self.index >= list.len() || list[self.index] >= self.list.items.len() {
                 return None;
             }
 
@@ -186,7 +186,7 @@ impl<'a, T> Iterator for FilterableListIterator<'a, T> {
 
             Some(&self.list.items[index])
         } else {
-            if self.list.items.len() == 0 || self.index >= self.list.items.len() {
+            if self.list.items.is_empty() || self.index >= self.list.items.len() {
                 return None;
             }
 
@@ -209,7 +209,7 @@ impl<'a, T> Iterator for FilterableListIteratorMut<'a, T> {
 
     fn next(&mut self) -> Option<&'a mut T> {
         if let Some(list) = &mut self.list.filtered {
-            if list.len() == 0 || self.index >= list.len() || list[self.index] >= self.list.items.len() {
+            if list.is_empty() || self.index >= list.len() || list[self.index] >= self.list.items.len() {
                 return None;
             }
 
@@ -218,7 +218,7 @@ impl<'a, T> Iterator for FilterableListIteratorMut<'a, T> {
 
             Some(item)
         } else {
-            if self.list.items.len() == 0 || self.index >= self.list.items.len() {
+            if self.list.items.is_empty() || self.index >= self.list.items.len() {
                 return None;
             }
 

--- a/src/app/lists/filterable_list.rs
+++ b/src/app/lists/filterable_list.rs
@@ -59,6 +59,12 @@ impl<T> FilterableList<T> {
         self.len
     }
 
+    /// Returns `true` if the filtered out list contains no elements.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
     /// Inserts an element at position `index` within the vector, shifting all elements after it to the right.  
     /// __Note__: _clears the current filter_
     pub fn insert(&mut self, index: usize, element: T) {

--- a/src/app/lists/header.rs
+++ b/src/app/lists/header.rs
@@ -16,12 +16,13 @@ pub struct Header {
     extra_space: usize,
 }
 
-impl Header {
-    /// Creates new [`Header`] instance
-    pub fn new() -> Self {
+impl Default for Header {
+    fn default() -> Self {
         Self::from(Column::new("N/A"), None)
     }
+}
 
+impl Header {
     /// Creates new [`Header`] instance with provided columns
     pub fn from(group_column: Column, extra_columns: Option<Box<[Column]>>) -> Self {
         let extra_columns_text = get_extra_columns_text(&extra_columns);

--- a/src/app/lists/item.rs
+++ b/src/app/lists/item.rs
@@ -1,5 +1,8 @@
 /// Contract for item with columns
 pub trait Row {
+    /// Returns `uid` of the item
+    fn uid(&self) -> Option<&str>;
+
     /// Returns `group` of the item
     fn group(&self) -> &str;
 

--- a/src/app/lists/kinds_list.rs
+++ b/src/app/lists/kinds_list.rs
@@ -9,18 +9,12 @@ use crate::{
 use super::{FilterableList, Item, Row, ScrollableList};
 
 /// Kubernetes kinds list
+#[derive(Default)]
 pub struct KindsList {
     pub list: ScrollableList<Kind>,
 }
 
 impl KindsList {
-    /// Creates new [`KindsList`] instance
-    pub fn new() -> Self {
-        KindsList {
-            list: ScrollableList::new(),
-        }
-    }
-
     /// Updates [`KindsList`] with new data from [`Vec<Kind>`]
     pub fn update(&mut self, kinds: Option<Vec<Kind>>, sort_by: usize, is_descending: bool) {
         if let Some(new_list) = kinds {

--- a/src/app/lists/kinds_list.rs
+++ b/src/app/lists/kinds_list.rs
@@ -1,12 +1,12 @@
 use delegate::delegate;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use crate::{
     kubernetes::resources::Kind,
     ui::{colors::TextColors, theme::Theme, ResponseEvent, Responsive, Table, ViewType},
 };
 
-use super::{FilterableList, Item, ScrollableList};
+use super::{FilterableList, Item, Row, ScrollableList};
 
 /// Kubernetes kinds list
 pub struct KindsList {
@@ -21,19 +21,18 @@ impl KindsList {
         }
     }
 
-    /// Updates [`KindsList`] with new data from [`Vec<Kind>`].  
-    /// Simplified version, takes care only about highlighted item.
+    /// Updates [`KindsList`] with new data from [`Vec<Kind>`]
     pub fn update(&mut self, kinds: Option<Vec<Kind>>, sort_by: usize, is_descending: bool) {
-        if let Some(list) = kinds {
-            let highlighted = self.list.get_highlighted_item_name().unwrap_or("").to_owned();
-            self.list.items = Some(FilterableList::from(list.into_iter().map(|i| Item::new(i)).collect()));
-            self.list.sort(sort_by, is_descending);
-            if !highlighted.is_empty() {
-                self.list.highlight_item_by_name(&highlighted);
+        if let Some(new_list) = kinds {
+            self.list.dirty(false);
+
+            if let Some(old_list) = &mut self.list.items {
+                update_old_list(old_list, new_list);
+            } else {
+                self.list.items = create_new_list(new_list);
             }
-        } else {
-            self.list.items = None;
-            self.list.highlighted = None;
+
+            self.list.sort(sort_by, is_descending);
         }
     }
 }
@@ -54,8 +53,8 @@ impl Table for KindsList {
             fn sort(&mut self, column_no: usize, is_descending: bool);
             fn get_highlighted_item_index(&self) -> Option<usize>;
             fn get_highlighted_item_name(&self) -> Option<&str>;
-            fn highlight_item_by_name(&mut self, name: &str);
-            fn highlight_item_by_name_start(&mut self, text: &str);
+            fn highlight_item_by_name(&mut self, name: &str) -> bool;
+            fn highlight_item_by_name_start(&mut self, text: &str) -> bool;
             fn highlight_first_item(&mut self) -> bool;
             fn deselect_all(&mut self);
             fn invert_selection(&mut self);
@@ -75,5 +74,61 @@ impl Table for KindsList {
 
     fn get_header(&self, _view: ViewType, width: usize) -> String {
         format!("{1:<0$}", width, "KIND")
+    }
+}
+
+fn update_old_list(old_list: &mut FilterableList<Item<Kind>>, new_list: Vec<Kind>) {
+    let mut unique = HashSet::new();
+    let mut multiple = HashSet::new();
+
+    for new_item in new_list.into_iter() {
+        let name = new_item.name.clone();
+        if unique.contains(&name) {
+            multiple.insert(name);
+        } else {
+            unique.insert(name);
+        }
+
+        let old_item = old_list.full_iter_mut().find(|i| i.data.uid() == new_item.uid());
+        if let Some(old_item) = old_item {
+            old_item.data = new_item;
+            old_item.is_dirty = true;
+        } else {
+            old_list.push(Item::dirty(new_item));
+        }
+    }
+
+    old_list.full_retain(|i| i.is_dirty || i.is_fixed);
+
+    mark_multiple(old_list, &multiple);
+}
+
+fn create_new_list(new_list: Vec<Kind>) -> Option<FilterableList<Item<Kind>>> {
+    let mut unique = HashSet::new();
+    let mut multiple = HashSet::new();
+
+    let mut list = Vec::with_capacity(new_list.len());
+
+    for new_item in new_list.into_iter() {
+        let name = new_item.name.clone();
+        if unique.contains(&name) {
+            multiple.insert(name);
+        } else {
+            unique.insert(name);
+        }
+
+        list.push(Item::new(new_item));
+    }
+
+    let mut list = FilterableList::from(list);
+
+    mark_multiple(&mut list, &multiple);
+
+    Some(list)
+}
+
+fn mark_multiple(list: &mut FilterableList<Item<Kind>>, multiple: &HashSet<String>) {
+    for item in list.full_iter_mut() {
+        item.data.multiple = multiple.contains(item.data.name());
     }
 }

--- a/src/app/lists/resources_list.rs
+++ b/src/app/lists/resources_list.rs
@@ -20,19 +20,20 @@ pub struct ResourcesList {
     pub list: ScrollableList<Resource>,
 }
 
-impl ResourcesList {
-    /// Creates new [`ResourcesList`] instance
-    pub fn new() -> Self {
+impl Default for ResourcesList {
+    fn default() -> Self {
         ResourcesList {
             kind: String::new(),
             kind_plural: String::new(),
             group: String::new(),
             scope: Scope::Cluster,
-            header: Header::new(),
-            list: ScrollableList::new(),
+            header: Header::default(),
+            list: ScrollableList::default(),
         }
     }
+}
 
+impl ResourcesList {
     /// Creates new [`ResourcesList`] instance from [`ScrollableList`]
     pub fn from(list: ScrollableList<Resource>) -> Self {
         ResourcesList {
@@ -40,7 +41,7 @@ impl ResourcesList {
             kind_plural: String::new(),
             group: String::new(),
             scope: Scope::Cluster,
-            header: Header::new(),
+            header: Header::default(),
             list,
         }
     }
@@ -108,7 +109,7 @@ impl ResourcesList {
 
             old_list.full_retain(|i| i.is_dirty || i.is_fixed);
         } else {
-            self.list.items = Some(FilterableList::from(new_list.into_iter().map(|i| Item::new(i)).collect()));
+            self.list.items = Some(FilterableList::from(new_list.into_iter().map(Item::new).collect()));
         }
 
         self.update_data_lengths();

--- a/src/app/lists/resources_list.rs
+++ b/src/app/lists/resources_list.rs
@@ -14,6 +14,7 @@ use super::{FilterableList, Header, Item, Row, ScrollableList};
 pub struct ResourcesList {
     pub kind: String,
     pub kind_plural: String,
+    pub group: String,
     pub scope: Scope,
     pub header: Header,
     pub list: ScrollableList<Resource>,
@@ -25,6 +26,7 @@ impl ResourcesList {
         ResourcesList {
             kind: String::new(),
             kind_plural: String::new(),
+            group: String::new(),
             scope: Scope::Cluster,
             header: Header::new(),
             list: ScrollableList::new(),
@@ -36,6 +38,7 @@ impl ResourcesList {
         ResourcesList {
             kind: String::new(),
             kind_plural: String::new(),
+            group: String::new(),
             scope: Scope::Cluster,
             header: Header::new(),
             list,
@@ -46,7 +49,7 @@ impl ResourcesList {
     /// Returns `true` if the kind was also changed during the update.
     pub fn update(&mut self, result: Option<ObserverResult>, sort_by: usize, is_descending: bool) -> bool {
         if let Some(result) = result {
-            let updated = self.update_kind(result.kind, result.kind_plural, result.scope);
+            let updated = self.update_kind(result.kind, result.kind_plural, result.group, result.scope);
             self.update_list(result.list.iter().map(|r| Resource::from(&self.kind, r)).collect());
             self.list.sort(sort_by, is_descending);
 
@@ -66,13 +69,14 @@ impl ResourcesList {
     }
 
     /// Returns `true` if kind was changed
-    fn update_kind(&mut self, kind: String, kind_plural: String, scope: Scope) -> bool {
-        if self.kind == kind {
+    fn update_kind(&mut self, kind: String, kind_plural: String, group: String, scope: Scope) -> bool {
+        if self.kind == kind && self.group == group {
             return false;
         }
 
         self.kind = kind;
         self.kind_plural = kind_plural;
+        self.group = group;
         self.scope = scope.clone();
         self.header = Resource::header(&self.kind);
         self.list.remove_fixed();
@@ -93,7 +97,7 @@ impl ResourcesList {
 
         if let Some(old_list) = &mut self.list.items {
             for new_item in new_list.into_iter() {
-                let old_item = old_list.full_iter_mut().find(|i| i.data.get_uid() == new_item.get_uid());
+                let old_item = old_list.full_iter_mut().find(|i| i.data.uid() == new_item.uid());
                 if let Some(old_item) = old_item {
                     old_item.data = new_item;
                     old_item.is_dirty = true;
@@ -103,7 +107,6 @@ impl ResourcesList {
             }
 
             old_list.full_retain(|i| i.is_dirty || i.is_fixed);
-            self.list.recover_highlighted_item_index();
         } else {
             self.list.items = Some(FilterableList::from(new_list.into_iter().map(|i| Item::new(i)).collect()));
         }
@@ -146,8 +149,8 @@ impl Table for ResourcesList {
             fn sort(&mut self, column_no: usize, is_descending: bool);
             fn get_highlighted_item_index(&self) -> Option<usize>;
             fn get_highlighted_item_name(&self) -> Option<&str>;
-            fn highlight_item_by_name(&mut self, name: &str);
-            fn highlight_item_by_name_start(&mut self, text: &str);
+            fn highlight_item_by_name(&mut self, name: &str) -> bool;
+            fn highlight_item_by_name_start(&mut self, text: &str) -> bool;
             fn highlight_first_item(&mut self) -> bool;
             fn deselect_all(&mut self);
             fn invert_selection(&mut self);

--- a/src/app/observer.rs
+++ b/src/app/observer.rs
@@ -46,11 +46,10 @@ pub struct BgObserver {
     has_error: Arc<AtomicBool>,
 }
 
-impl BgObserver {
-    /// Creates new [`BgObserver`] instance
-    pub fn new() -> Self {
+impl Default for BgObserver {
+    fn default() -> Self {
         let (context_tx, context_rx) = mpsc::unbounded_channel();
-        BgObserver {
+        Self {
             resource: String::new(),
             namespace: None,
             scope: Scope::Cluster,
@@ -61,7 +60,9 @@ impl BgObserver {
             has_error: Arc::new(AtomicBool::new(false)),
         }
     }
+}
 
+impl BgObserver {
     /// Starts new [`BgObserver`] task
     pub fn start(
         &mut self,
@@ -209,7 +210,7 @@ impl BgObserver {
 
     /// Drains waiting [`ObserverResult`]s
     pub fn drain(&mut self) {
-        while let Ok(_) = self.context_rx.try_recv() {}
+        while self.context_rx.try_recv().is_ok() {}
     }
 
     /// Returns currently observed resource name

--- a/src/app/observer.rs
+++ b/src/app/observer.rs
@@ -79,6 +79,7 @@ impl BgObserver {
 
         let _kind = ar.kind.clone();
         let _kind_plural = ar.plural.to_lowercase();
+        let _group = ar.group.clone();
         self.scope = cap.scope.clone();
         let _scope = cap.scope.clone();
 
@@ -99,6 +100,7 @@ impl BgObserver {
                             .send(ObserverResult::new(
                                 _kind.clone(),
                                 _kind_plural.clone(),
+                                _group.clone(),
                                 _scope.clone(),
                                 objects,
                             ))

--- a/src/app/observer_result.rs
+++ b/src/app/observer_result.rs
@@ -7,16 +7,18 @@ use kube::{
 pub struct ObserverResult {
     pub kind: String,
     pub kind_plural: String,
+    pub group: String,
     pub scope: Scope,
     pub list: ObjectList<DynamicObject>,
 }
 
 impl ObserverResult {
     /// Creates new background observer result
-    pub fn new(kind: String, kind_plural: String, scope: Scope, list: ObjectList<DynamicObject>) -> Self {
+    pub fn new(kind: String, kind_plural: String, group: String, scope: Scope, list: ObjectList<DynamicObject>) -> Self {
         ObserverResult {
             kind,
             kind_plural,
+            group,
             scope,
             list,
         }

--- a/src/app/worker.rs
+++ b/src/app/worker.rs
@@ -27,10 +27,10 @@ impl BgWorker {
     /// Creates new [`BgWorker`] instance
     pub fn new(client: KubernetesClient) -> Self {
         Self {
-            namespaces: BgObserver::new(),
-            resources: BgObserver::new(),
-            discovery: BgDiscovery::new(),
-            executor: BgExecutor::new(),
+            namespaces: BgObserver::default(),
+            resources: BgObserver::default(),
+            discovery: BgDiscovery::default(),
+            executor: BgExecutor::default(),
             client,
             list: None,
         }
@@ -66,7 +66,7 @@ impl BgWorker {
 
     /// Restarts (if needed) the resources observer to change observed namespace
     pub fn restart_new_namespace(&mut self, resource_namespace: Option<String>) -> Result<Scope, BgObserverError> {
-        let discovery = self.get_resource(&self.resources.get_resource_name());
+        let discovery = self.get_resource(self.resources.get_resource_name());
         self.resources
             .restart_new_namespace(&self.client, resource_namespace, discovery)
     }
@@ -89,17 +89,13 @@ impl BgWorker {
 
     /// Returns list of discovered kubernetes kinds
     pub fn get_kinds_list(&self) -> Option<Vec<Kind>> {
-        if let Some(discovery) = &self.list {
-            Some(
-                discovery
-                    .iter()
-                    .filter(|(_, cap)| cap.supports_operation(verbs::LIST))
-                    .map(|(ar, _)| Kind::new(ar.group.to_owned(), ar.plural.to_owned(), ar.version.to_owned()))
-                    .collect::<Vec<Kind>>(),
-            )
-        } else {
-            None
-        }
+        self.list.as_ref().map(|discovery| {
+            discovery
+                .iter()
+                .filter(|(_, cap)| cap.supports_operation(verbs::LIST))
+                .map(|(ar, _)| Kind::new(ar.group.to_owned(), ar.plural.to_owned(), ar.version.to_owned()))
+                .collect::<Vec<Kind>>()
+        })
     }
 
     /// Checks and updates discovered resources list, returns `true` if discovery was updated
@@ -164,29 +160,27 @@ impl BgWorker {
         if group.is_empty() {
             self.get_resource_no_group(name)
         } else {
-            if let Some(list) = &self.list {
-                list.iter()
+            self.list.as_ref().and_then(|discovery| {
+                discovery
+                    .iter()
                     .find(|(ar, _)| {
                         group.eq_ignore_ascii_case(&ar.group)
                             && (name.eq_ignore_ascii_case(&ar.kind) || name.eq_ignore_ascii_case(&ar.plural))
                     })
                     .map(|(ar, cap)| (ar.clone(), cap.clone()))
-            } else {
-                None
-            }
+            })
         }
     }
 
     /// Gets first matching [`ApiResource`] and [`ApiCapabilities`] for the resource name ignoring group
     fn get_resource_no_group(&self, name: &str) -> Option<(ApiResource, ApiCapabilities)> {
-        if let Some(list) = &self.list {
-            list.iter()
+        self.list.as_ref().and_then(|discovery| {
+            discovery
+                .iter()
                 .filter(|(ar, _)| name.eq_ignore_ascii_case(&ar.kind) || name.eq_ignore_ascii_case(&ar.plural))
                 .min_by_key(|(ar, _)| &ar.group)
                 .map(|(ar, cap)| (ar.clone(), cap.clone()))
-        } else {
-            None
-        }
+        })
     }
 }
 

--- a/src/kubernetes/mod.rs
+++ b/src/kubernetes/mod.rs
@@ -1,5 +1,5 @@
-pub const ALL_NAMESPACES: &'static str = "all";
-pub const NAMESPACES: &'static str = "namespaces";
+pub const ALL_NAMESPACES: &str = "all";
+pub const NAMESPACES: &str = "namespaces";
 
 pub mod client;
 pub mod resources;

--- a/src/kubernetes/resources/kind.rs
+++ b/src/kubernetes/resources/kind.rs
@@ -3,42 +3,64 @@ use crate::{app::lists::Row, utils::truncate};
 /// Represents kubernetes kind
 pub struct Kind {
     pub uid: Option<String>,
+    pub group: String,
     pub name: String,
+    pub full_name: String,
+    pub version: String,
+    pub multiple: bool,
 }
 
 impl Kind {
     /// Creates new [`Kind`] instance
-    pub fn new(name: &str) -> Self {
-        Self {
-            uid: Some(format!("_{}_", name)),
-            name: name.to_owned(),
-        }
-    }
+    pub fn new(group: String, name: String, version: String) -> Self {
+        let full_name = if group.is_empty() {
+            name.clone()
+        } else {
+            format!("{}.{}", name, group)
+        };
 
-    /// Returns `UID` of this kubernetes kind
-    pub fn get_uid(&self) -> Option<&str> {
-        self.uid.as_deref()
+        Self {
+            uid: Some(format!("_{}:{}:{}_", group, name, version)),
+            group,
+            name,
+            full_name,
+            version,
+            multiple: false,
+        }
     }
 }
 
 impl Row for Kind {
+    fn uid(&self) -> Option<&str> {
+        self.uid.as_deref()
+    }
+
     fn group(&self) -> &str {
-        ""
+        &self.group
     }
 
     fn name(&self) -> &str {
-        &self.name
+        if self.multiple {
+            &self.full_name
+        } else {
+            &self.name
+        }
     }
 
     fn get_name(&self, width: usize) -> String {
-        format!("{1:<0$}", width, truncate(self.name.as_str(), width))
+        if self.multiple {
+            format!("{1:<0$}", width, truncate(self.full_name.as_str(), width))
+        } else {
+            format!("{1:<0$}", width, truncate(self.name.as_str(), width))
+        }
     }
 
     fn column_text(&self, column: usize) -> &str {
-        if column == 1 {
-            self.name.as_str()
-        } else {
-            "n/a"
+        match column {
+            0 => &self.group,
+            1 => self.name(),
+            2 => &self.version,
+            _ => "n/a",
         }
     }
 }

--- a/src/kubernetes/resources/kinds/pod.rs
+++ b/src/kubernetes/resources/kinds/pod.rs
@@ -64,23 +64,20 @@ pub fn header() -> Header {
     )
 }
 
-fn get_restarts(containers: &Vec<Value>) -> u16 {
+fn get_restarts(containers: &[Value]) -> u16 {
     containers
         .iter()
         .map(|c| c["restartCount"].as_u64().unwrap_or(0))
         .sum::<u64>() as u16
 }
 
-fn get_ready(containers: &Vec<Value>) -> (String, bool) {
-    let ready = containers
-        .iter()
-        .filter(|c| c["ready"].as_bool().unwrap_or_default() == true)
-        .count();
+fn get_ready(containers: &[Value]) -> (String, bool) {
+    let ready = containers.iter().filter(|c| c["ready"].as_bool().unwrap_or_default()).count();
 
     (format!("{}/{}", ready, containers.len()), ready == containers.len())
 }
 
-fn any_terminated(containers: &Vec<Value>) -> bool {
+fn any_terminated(containers: &[Value]) -> bool {
     containers.iter().any(|c| c.get("terminated").is_some())
 }
 

--- a/src/kubernetes/resources/resource.rs
+++ b/src/kubernetes/resources/resource.rs
@@ -83,11 +83,6 @@ impl Resource {
         }
     }
 
-    /// Returns `UID` of this kubernetes resource
-    pub fn get_uid(&self) -> Option<&str> {
-        self.uid.as_deref()
-    }
-
     /// Returns [`TextColors`] for this kubernetes resource considering `theme` and other data
     pub fn get_colors(&self, theme: &Theme, is_active: bool, is_selected: bool) -> TextColors {
         if let Some(data) = &self.data {
@@ -171,6 +166,10 @@ impl Resource {
 }
 
 impl Row for Resource {
+    fn uid(&self) -> Option<&str> {
+        self.uid.as_deref()
+    }
+
     fn group(&self) -> &str {
         self.namespace.as_deref().unwrap_or_default()
     }

--- a/src/kubernetes/resources/resource.rs
+++ b/src/kubernetes/resources/resource.rs
@@ -111,7 +111,7 @@ impl Resource {
                 .as_ref()
                 .map(kubernetes::utils::format_timestamp)
                 .as_deref()
-                .unwrap_or_else(|| "n/a")
+                .unwrap_or("n/a")
         )
     }
 
@@ -127,7 +127,7 @@ impl Resource {
                 .as_ref()
                 .map(kubernetes::utils::format_timestamp)
                 .as_deref()
-                .unwrap_or_else(|| "n/a")
+                .unwrap_or("n/a")
         )
     }
 
@@ -160,8 +160,8 @@ impl Resource {
         text
     }
 
-    fn get_extra_values(&self) -> Option<&Box<[Option<String>]>> {
-        self.data.as_ref().map(|data| &data.extra_values)
+    fn get_extra_values(&self) -> Option<&[Option<String>]> {
+        self.data.as_ref().map(|data| &*data.extra_values)
     }
 }
 

--- a/src/logging/utils.rs
+++ b/src/logging/utils.rs
@@ -17,7 +17,7 @@ pub fn initialize() -> Result<tracing_appender::non_blocking::WorkerGuard> {
     let (non_blocking_appender, guard) = tracing_appender::non_blocking(appender);
 
     let timer = time::format_description::parse("[year]-[month padding:zero]-[day padding:zero] [hour]:[minute]:[second]")?;
-    let time_offset = time::UtcOffset::current_local_offset().unwrap_or_else(|_| time::UtcOffset::UTC);
+    let time_offset = time::UtcOffset::current_local_offset().unwrap_or(time::UtcOffset::UTC);
     let timer = tracing_subscriber::fmt::time::OffsetTime::new(time_offset, timer);
 
     let env_filter = tracing_subscriber::filter::EnvFilter::try_from_default_env()

--- a/src/ui/colors.rs
+++ b/src/ui/colors.rs
@@ -11,19 +11,19 @@ pub struct TextColors {
     pub bg: Color,
 }
 
-impl TextColors {
-    /// Returns new [`TextColors`] instance
-    pub fn new(fg: Color, bg: Color) -> Self {
-        TextColors { fg, bg }
-    }
-}
-
 impl Default for TextColors {
     fn default() -> Self {
         Self {
             fg: Color::Black,
             bg: Color::Reset,
         }
+    }
+}
+
+impl TextColors {
+    /// Returns new [`TextColors`] instance
+    pub fn new(fg: Color, bg: Color) -> Self {
+        TextColors { fg, bg }
     }
 }
 
@@ -49,7 +49,7 @@ impl<'de> Deserialize<'de> for TextColors {
 /// Internal [`Visitor`] for deserializing [`TextColors`]
 struct TextColorsVisitor;
 
-impl<'de> Visitor<'de> for TextColorsVisitor {
+impl Visitor<'_> for TextColorsVisitor {
     type Value = TextColors;
 
     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
@@ -96,12 +96,10 @@ impl LineColors {
             } else {
                 self.selected
             }
+        } else if is_active {
+            self.normal_hl
         } else {
-            if is_active {
-                self.normal_hl
-            } else {
-                self.normal
-            }
+            self.normal
         }
     }
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -40,6 +40,11 @@ pub trait Table: Responsive {
     /// Returns the number of elements in the list.
     fn len(&self) -> usize;
 
+    /// Returns `true` if the list contains no elements.
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     /// Returns `true` if list is filtered
     fn is_filtered(&self) -> bool;
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -59,11 +59,11 @@ pub trait Table: Responsive {
     fn get_highlighted_item_name(&self) -> Option<&str>;
 
     /// Highlights element on list by its name
-    fn highlight_item_by_name(&mut self, name: &str);
+    fn highlight_item_by_name(&mut self, name: &str) -> bool;
 
     /// Highlights first element on list which name starts with `text`.  
     /// Returns `true` if element was found and selected.
-    fn highlight_item_by_name_start(&mut self, text: &str);
+    fn highlight_item_by_name_start(&mut self, text: &str) -> bool;
 
     /// Highlights first item on list, returns `true` on success
     fn highlight_first_item(&mut self) -> bool;

--- a/src/ui/pages/home.rs
+++ b/src/ui/pages/home.rs
@@ -36,13 +36,13 @@ impl HomePage {
     /// Creates a new home page
     pub fn new(app_data: SharedAppData) -> Self {
         let header = HeaderPane::new(Rc::clone(&app_data));
-        let list = ListPane::new(Rc::clone(&app_data), ResourcesList::new(), ViewType::Compact);
+        let list = ListPane::new(Rc::clone(&app_data), ResourcesList::default(), ViewType::Compact);
         let footer = FooterPane::new(Rc::clone(&app_data));
 
         let ns_selector = Selector::new(
             "NAMESPACE",
             Rc::clone(&app_data),
-            ResourcesList::new(),
+            ResourcesList::default(),
             SelectorPosition::Left,
             ResponseEvent::ChangeNamespace,
             30,
@@ -51,7 +51,7 @@ impl HomePage {
         let res_selector = Selector::new(
             "RESOURCE",
             Rc::clone(&app_data),
-            KindsList::new(),
+            KindsList::default(),
             SelectorPosition::Right,
             ResponseEvent::ChangeKind,
             35,

--- a/src/ui/pages/home.rs
+++ b/src/ui/pages/home.rs
@@ -128,6 +128,7 @@ impl HomePage {
             let mut data = self.app_data.borrow_mut();
             data.current.kind = self.list.items.kind.clone();
             data.current.kind_plural = self.list.items.kind_plural.clone();
+            data.current.group = self.list.items.group.clone();
             data.current.scope = self.list.items.scope.clone();
             data.current.count = self.list.items.list.len();
         } else {
@@ -175,11 +176,12 @@ impl HomePage {
         }
 
         if key.code == KeyCode::Left && self.list.items.scope == Scope::Namespaced {
-            self.ns_selector.show_selected(&self.app_data.borrow().current.namespace);
+            self.ns_selector.show_selected(&self.app_data.borrow().current.namespace, "");
         }
 
         if key.code == KeyCode::Right {
-            self.res_selector.show_selected(&self.list.items.kind_plural);
+            self.res_selector
+                .show_selected(&self.list.items.kind_plural, &self.list.items.group);
         }
 
         if key.code == KeyCode::Esc && self.list.items.kind_plural != NAMESPACES {

--- a/src/ui/tui.rs
+++ b/src/ui/tui.rs
@@ -134,12 +134,9 @@ impl Drop for Tui {
 }
 
 fn process_crossterm_event(event: Event, sender: &UnboundedSender<TuiEvent>) {
-    match event {
-        Event::Key(key) => {
-            if key.kind == KeyEventKind::Press {
-                sender.send(TuiEvent::Key(key)).unwrap();
-            }
+    if let Event::Key(key) = event {
+        if key.kind == KeyEventKind::Press {
+            sender.send(TuiEvent::Key(key)).unwrap();
         }
-        _ => {}
     }
 }

--- a/src/ui/widgets/buttons_group.rs
+++ b/src/ui/widgets/buttons_group.rs
@@ -28,7 +28,7 @@ impl ButtonsGroup {
 
     /// Returns result for the button under provided index
     pub fn result(&self, index: usize) -> ResponseEvent {
-        if self.buttons.len() == 0 {
+        if self.buttons.is_empty() {
             return ResponseEvent::NotHandled;
         }
 
@@ -37,7 +37,7 @@ impl ButtonsGroup {
 
     /// Focus button under provided index
     pub fn focus(&mut self, index: usize) {
-        if self.buttons.len() > 0 {
+        if !self.buttons.is_empty() {
             self.buttons[self.focused].set_focus(false);
             self.focused = index.clamp(0, self.buttons.len() - 1);
             self.buttons[self.focused].set_focus(true);
@@ -46,7 +46,7 @@ impl ButtonsGroup {
 
     /// Draws [`ButtonsGroup`] on the provided frame area
     pub fn draw(&self, frame: &mut ratatui::Frame<'_>, area: Rect) {
-        if self.buttons.len() == 0 {
+        if self.buttons.is_empty() {
             return;
         }
 
@@ -104,7 +104,7 @@ impl ButtonsGroup {
 
 impl Responsive for ButtonsGroup {
     fn process_key(&mut self, key: KeyEvent) -> ResponseEvent {
-        if self.buttons.len() == 0 {
+        if self.buttons.is_empty() {
             return ResponseEvent::NotHandled;
         }
 

--- a/src/ui/widgets/dialog.rs
+++ b/src/ui/widgets/dialog.rs
@@ -21,10 +21,16 @@ pub struct Dialog {
     default_button: usize,
 }
 
+impl Default for Dialog {
+    fn default() -> Self {
+        Self::new(String::new(), vec![], 0, TextColors::default())
+    }
+}
+
 impl Dialog {
     /// Creates new [`Dialog`] instance
     pub fn new(message: String, buttons: Vec<Button>, width: u16, colors: TextColors) -> Self {
-        let default_button = if buttons.len() > 0 { buttons.len() - 1 } else { 0 };
+        let default_button = if buttons.is_empty() { 0 } else { buttons.len() - 1 };
         let mut buttons = ButtonsGroup::new(buttons);
         buttons.focus(default_button);
 
@@ -95,12 +101,6 @@ impl Responsive for Dialog {
         }
 
         result
-    }
-}
-
-impl Default for Dialog {
-    fn default() -> Self {
-        Self::new(String::new(), vec![], 0, TextColors::default())
     }
 }
 

--- a/src/ui/widgets/selector.rs
+++ b/src/ui/widgets/selector.rs
@@ -76,9 +76,15 @@ impl<T: Table> Selector<T> {
     }
 
     /// Marks selector as visible and selects item by name
-    pub fn show_selected(&mut self, selected_name: &str) {
+    pub fn show_selected(&mut self, selected_name: &str, selected_group: &str) {
         self.items.filter(None);
-        self.items.highlight_item_by_name(selected_name);
+        if selected_group.is_empty()
+            || !self
+                .items
+                .highlight_item_by_name(&format!("{}.{}", selected_name, selected_group))
+        {
+            self.items.highlight_item_by_name(selected_name);
+        }
         self.show();
     }
 


### PR DESCRIPTION
Right selector in the main app view lists resource names that user can select and change. This list only showed the value of resource plural name, which was insufficient. Now resources with the same name are displayed with their group.