### PR TITLE
Separate config file for application history

### DIFF
--- a/src/app/app.rs
+++ b/src/app/app.rs
@@ -46,7 +46,7 @@ impl App {
         let data = Rc::new(RefCell::new(AppData::new(config, history)));
         let footer = Footer::new(Rc::clone(&data));
         let worker = Rc::new(RefCell::new(BgWorker::new(footer.get_messages_sender())));
-        let resources = ResourcesView::new(Rc::clone(&data));
+        let resources = ResourcesView::new(Rc::clone(&data), Rc::clone(&worker));
         let client_manager = KubernetesClientManager::new(Rc::clone(&data), Rc::clone(&worker), footer.get_messages_sender());
 
         Ok(Self {

--- a/src/app/app.rs
+++ b/src/app/app.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 
 use super::{
-    AppData, BgWorker, BgWorkerError, Config, ConfigWatcher, KubernetesClientManager, SharedAppData, SharedBgWorker,
+    AppData, BgWorker, BgWorkerError, Config, ConfigWatcher, History, KubernetesClientManager, SharedAppData, SharedBgWorker,
     commands::{
         Command, CommandResult, KubernetesClientError, KubernetesClientResult, ListKubeContextsCommand, ResourceYamlError,
         ResourceYamlResult,
@@ -35,14 +35,15 @@ pub struct App {
     view: Option<Box<dyn View>>,
     footer: Footer,
     worker: SharedBgWorker,
-    watcher: ConfigWatcher,
+    config_watcher: ConfigWatcher<Config>,
+    history_watcher: ConfigWatcher<History>,
     client_manager: KubernetesClientManager,
 }
 
 impl App {
     /// Creates new [`App`] instance.
-    pub fn new(config: Config) -> Result<Self> {
-        let data = Rc::new(RefCell::new(AppData::new(config)));
+    pub fn new(config: Config, history: History) -> Result<Self> {
+        let data = Rc::new(RefCell::new(AppData::new(config, history)));
         let footer = Footer::new(Rc::clone(&data));
         let worker = Rc::new(RefCell::new(BgWorker::new(footer.get_messages_sender())));
         let resources = ResourcesView::new(Rc::clone(&data));
@@ -55,7 +56,8 @@ impl App {
             view: None,
             footer,
             worker,
-            watcher: Config::watcher(),
+            config_watcher: Config::watcher(),
+            history_watcher: History::watcher(),
             client_manager,
         })
     }
@@ -66,7 +68,8 @@ impl App {
             .request_new_client(context.clone(), kind, namespace.clone());
         self.resources
             .set_resources_info(context, namespace, String::default(), Scope::Cluster);
-        self.watcher.start()?;
+        self.config_watcher.start()?;
+        self.history_watcher.start()?;
         self.tui.enter_terminal()?;
 
         Ok(())
@@ -75,14 +78,16 @@ impl App {
     /// Cancels all app tasks.
     pub fn cancel(&mut self) {
         self.worker.borrow_mut().cancel_all();
-        self.watcher.cancel();
+        self.config_watcher.cancel();
+        self.history_watcher.cancel();
         self.tui.cancel();
     }
 
     /// Stops app.
     pub fn stop(&mut self) -> Result<()> {
         self.worker.borrow_mut().stop_all();
-        self.watcher.stop();
+        self.config_watcher.stop();
+        self.history_watcher.stop();
         self.tui.exit_terminal()?;
 
         Ok(())
@@ -90,8 +95,12 @@ impl App {
 
     /// Process all waiting events.
     pub fn process_events(&mut self) -> Result<ExecutionFlow> {
-        if let Some(config) = self.watcher.try_next() {
+        if let Some(config) = self.config_watcher.try_next() {
             self.data.borrow_mut().config = config;
+        }
+
+        if let Some(history) = self.history_watcher.try_next() {
+            self.data.borrow_mut().history = history;
         }
 
         self.process_commands_results();
@@ -237,7 +246,7 @@ impl App {
 
     /// Runs command to list kube contexts from the current config.
     fn list_kube_contexts(&mut self) {
-        let kube_config_path = self.data.borrow().config.kube_config_path().map(String::from);
+        let kube_config_path = self.data.borrow().history.kube_config_path().map(String::from);
         self.worker
             .borrow_mut()
             .run_command(Command::ListKubeContexts(ListKubeContextsCommand { kube_config_path }));
@@ -288,22 +297,22 @@ impl App {
     /// **Note** that this means the resource list will change soon.
     fn process_resources_change(&mut self, kind: Option<String>, namespace: Option<String>, scope: Option<Scope>) {
         self.resources.clear_list_data();
-        self.update_configuration(kind, namespace);
+        self.update_history_data(kind, namespace);
         if let Some(scope) = scope {
             self.set_page_view(scope);
         }
     }
 
-    /// Updates `kind` and `namespace` in the configuration and saves it to a file.
-    fn update_configuration(&mut self, kind: Option<String>, namespace: Option<String>) {
+    /// Updates `kind` and `namespace` in the app history data and saves it to a file.
+    fn update_history_data(&mut self, kind: Option<String>, namespace: Option<String>) {
         let context = { self.data.borrow().current.context.clone() };
         self.data
             .borrow_mut()
-            .config
+            .history
             .create_or_update_context(context, kind, namespace);
 
-        self.watcher.skip_next();
-        self.worker.borrow_mut().save_configuration(self.data.borrow().config.clone());
+        self.history_watcher.skip_next();
+        self.worker.borrow_mut().save_history(self.data.borrow().history.clone());
     }
 
     /// Sets page view from resource scope.

--- a/src/app/commands/mod.rs
+++ b/src/app/commands/mod.rs
@@ -5,18 +5,21 @@ pub use self::get_yaml::*;
 pub use self::list_contexts::*;
 pub use self::new_kubernetes_client::*;
 pub use self::save_configuration::*;
+pub use self::save_history::*;
 
 mod delete_resources;
 mod get_yaml;
 mod list_contexts;
 mod new_kubernetes_client;
 mod save_configuration;
+mod save_history;
 
 /// List of all possible commands for [BgExecutor](super::BgExecutor).
 pub enum Command {
     ListKubeContexts(ListKubeContextsCommand),
     NewKubernetesClient(Box<NewKubernetesClientCommand>),
     SaveConfiguration(Box<SaveConfigurationCommand>),
+    SaveHistory(Box<SaveHistoryCommand>),
     DeleteResource(Box<DeleteResourcesCommand>),
     GetYaml(Box<GetResourceYamlCommand>),
 }

--- a/src/app/commands/save_configuration.rs
+++ b/src/app/commands/save_configuration.rs
@@ -1,6 +1,6 @@
 use tracing::error;
 
-use crate::app::Config;
+use crate::app::{Config, Persistable};
 
 use super::CommandResult;
 

--- a/src/app/commands/save_history.rs
+++ b/src/app/commands/save_history.rs
@@ -1,0 +1,26 @@
+use tracing::error;
+
+use crate::app::{History, Persistable};
+
+use super::CommandResult;
+
+/// Command that saves provided app history data to a file.
+pub struct SaveHistoryCommand {
+    pub history: History,
+}
+
+impl SaveHistoryCommand {
+    /// Creates new [`SaveHistoryCommand`] instance.
+    pub fn new(history: History) -> Self {
+        Self { history }
+    }
+
+    /// Saves app history data to a file.
+    pub async fn execute(&self) -> Option<CommandResult> {
+        if let Err(error) = self.history.save().await {
+            error!("The history data cannot be saved to a file: {}", error);
+        }
+
+        None
+    }
+}

--- a/src/app/configuration/config.rs
+++ b/src/app/configuration/config.rs
@@ -1,12 +1,12 @@
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, path::PathBuf};
+use std::path::PathBuf;
 use tokio::{
     fs::File,
     io::{AsyncReadExt, AsyncWriteExt},
 };
 
-use crate::{app::ResourcesInfo, ui::theme::Theme, utils::calculate_hash};
+use crate::ui::theme::Theme;
 
 use super::ConfigWatcher;
 
@@ -22,78 +22,23 @@ pub enum ConfigError {
     SerializationError(#[from] serde_yaml::Error),
 }
 
-/// Keeps context configuration.
-#[derive(Serialize, Deserialize, Default, Clone)]
-pub struct ContextInfo {
-    pub name: String,
-    pub namespace: String,
-    pub kind: String,
-}
+pub trait Persistable<T> {
+    /// Loads configuration from the default file.
+    fn load() -> impl Future<Output = Result<T, ConfigError>> + Send;
 
-impl ContextInfo {
-    /// Creates new [`ContextInfo`] instance.
-    pub fn new(name: String) -> Self {
-        Self {
-            name,
-            ..Default::default()
-        }
-    }
-
-    /// Creates new [`ContextInfo`] instance from the [`ResourcesInfo`].
-    pub fn from(info: &ResourcesInfo) -> Self {
-        Self {
-            name: info.context.clone(),
-            namespace: info.namespace.as_str().into(),
-            kind: info.kind.clone(),
-        }
-    }
-
-    /// Optionally updates `kind` and / or `namespace`.
-    pub fn update(&mut self, kind: Option<String>, namespace: Option<String>) {
-        if let Some(namespace) = namespace {
-            self.namespace = namespace;
-        }
-
-        if let Some(kind) = kind {
-            self.kind = kind;
-        }
-    }
-}
-
-/// Keeps context configuration for individual kube config.
-#[derive(Serialize, Deserialize, Default, Clone)]
-pub struct KubeConfig {
-    pub current_context: Option<String>,
-    pub contexts: Vec<ContextInfo>,
-}
-
-impl KubeConfig {
-    /// Creates new [`KubeConfig`] instance.
-    pub fn new(context: String, kind: Option<String>, namespace: Option<String>) -> Self {
-        let mut new_context = ContextInfo::new(context.clone());
-        new_context.update(kind, namespace);
-
-        Self {
-            current_context: Some(context),
-            contexts: vec![new_context],
-        }
-    }
+    /// Saves configuration to the default file.
+    fn save(&self) -> impl Future<Output = Result<(), ConfigError>> + Send;
 }
 
 /// Application configuration.
 #[derive(Serialize, Deserialize, Default, Clone)]
 pub struct Config {
-    pub kube_configs: HashMap<String, KubeConfig>,
     pub theme: Theme,
-    #[serde(skip_serializing)]
-    current_kube_config: Option<String>,
-    #[serde(skip_serializing)]
-    current_hash: Option<String>,
 }
 
 impl Config {
     /// Returns watcher for configuration.
-    pub fn watcher() -> ConfigWatcher {
+    pub fn watcher() -> ConfigWatcher<Config> {
         ConfigWatcher::new(get_default_config_dir())
     }
 
@@ -111,9 +56,10 @@ impl Config {
             }
         }
     }
+}
 
-    /// Loads configuration from the default file located at `HOME/b4n/config.yaml`.
-    pub async fn load() -> Result<Self, ConfigError> {
+impl Persistable<Config> for Config {
+    async fn load() -> Result<Config, ConfigError> {
         let mut file = File::open(get_default_config_dir()).await?;
 
         let mut config_str = String::new();
@@ -122,8 +68,7 @@ impl Config {
         Ok(serde_yaml::from_str::<Config>(&config_str)?)
     }
 
-    /// Saves configuration to the default file located at `HOME/b4n/config.yaml`.
-    pub async fn save(&self) -> Result<(), ConfigError> {
+    async fn save(&self) -> Result<(), ConfigError> {
         let config_str = serde_yaml::to_string(self)?;
 
         let mut file = File::create(get_default_config_dir()).await?;
@@ -131,89 +76,6 @@ impl Config {
         file.flush().await?;
 
         Ok(())
-    }
-
-    /// Returns a kind stored in the configuration under a specific context name.
-    pub fn get_kind(&self, context: &str) -> Option<&str> {
-        if let Some(index) = self.context_index(context) {
-            Some(&self.kube_configs[self.config_key()].contexts[index].kind)
-        } else {
-            None
-        }
-    }
-
-    /// Returns a namespace stored in the configuration under a specific context name.
-    pub fn get_namespace(&self, context: &str) -> Option<&str> {
-        if let Some(index) = self.context_index(context) {
-            Some(&self.kube_configs[self.config_key()].contexts[index].namespace)
-        } else {
-            None
-        }
-    }
-
-    /// Gets the currently used kube config path.
-    pub fn kube_config_path(&self) -> Option<&str> {
-        self.current_kube_config.as_deref()
-    }
-
-    /// Sets the currently used kube config path.
-    pub fn set_kube_config_path(&mut self, path: Option<String>) {
-        if let Some(path) = path {
-            self.current_hash = Some(calculate_hash(&path, 8));
-            self.current_kube_config = Some(path);
-        } else {
-            self.current_hash = None;
-            self.current_kube_config = None;
-        }
-    }
-
-    /// Returns currently selected context name.
-    pub fn current_context(&self) -> Option<&str> {
-        self.current_config().and_then(|c| c.current_context.as_deref())
-    }
-
-    /// Creates or updates (if exists) context data.
-    pub fn create_or_update_context(&mut self, context: String, kind: Option<String>, namespace: Option<String>) {
-        if let Some(config) = self.current_config_mut() {
-            if let Some(index) = config.contexts.iter().position(|c| c.name == context) {
-                config.contexts[index].update(kind, namespace);
-            } else {
-                let mut context = ContextInfo::new(context.clone());
-                context.update(kind, namespace);
-                config.contexts.push(context);
-            }
-
-            config.current_context = Some(context);
-        } else {
-            self.kube_configs
-                .insert(self.config_key().to_owned(), KubeConfig::new(context, kind, namespace));
-        }
-    }
-
-    fn config_key(&self) -> &str {
-        match &self.current_hash {
-            Some(hash) => hash,
-            None => "default",
-        }
-    }
-
-    fn context_index(&self, context: &str) -> Option<usize> {
-        self.kube_configs
-            .get(self.config_key())
-            .and_then(|c| c.contexts.iter().position(|c| c.name == context))
-    }
-
-    fn current_config(&self) -> Option<&KubeConfig> {
-        self.kube_configs.get(self.config_key())
-    }
-
-    fn current_config_mut(&mut self) -> Option<&mut KubeConfig> {
-        let current_key = match &self.current_hash {
-            Some(hash) => hash,
-            None => "default",
-        };
-
-        self.kube_configs.get_mut(current_key)
     }
 }
 

--- a/src/app/configuration/history.rs
+++ b/src/app/configuration/history.rs
@@ -1,0 +1,212 @@
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use std::{collections::HashMap, path::PathBuf};
+use tokio::{
+    fs::File,
+    io::{AsyncReadExt, AsyncWriteExt},
+};
+
+use crate::{app::ResourcesInfo, utils::calculate_hash};
+
+use super::{ConfigError, ConfigWatcher, Persistable};
+
+/// Keeps context configuration.
+#[derive(Serialize, Deserialize, Default, Clone)]
+pub struct ContextInfo {
+    pub name: String,
+    pub namespace: String,
+    pub kind: String,
+}
+
+impl ContextInfo {
+    /// Creates new [`ContextInfo`] instance.
+    pub fn new(name: String) -> Self {
+        Self {
+            name,
+            ..Default::default()
+        }
+    }
+
+    /// Creates new [`ContextInfo`] instance from the [`ResourcesInfo`].
+    pub fn from(info: &ResourcesInfo) -> Self {
+        Self {
+            name: info.context.clone(),
+            namespace: info.namespace.as_str().into(),
+            kind: info.kind.clone(),
+        }
+    }
+
+    /// Optionally updates `kind` and / or `namespace`.
+    pub fn update(&mut self, kind: Option<String>, namespace: Option<String>) {
+        if let Some(namespace) = namespace {
+            self.namespace = namespace;
+        }
+
+        if let Some(kind) = kind {
+            self.kind = kind;
+        }
+    }
+}
+
+/// Keeps context configuration for individual kube config.
+#[derive(Serialize, Deserialize, Default, Clone)]
+pub struct KubeConfig {
+    pub current_context: Option<String>,
+    pub contexts: Vec<ContextInfo>,
+}
+
+impl KubeConfig {
+    /// Creates new [`KubeConfig`] instance.
+    pub fn new(context: String, kind: Option<String>, namespace: Option<String>) -> Self {
+        let mut new_context = ContextInfo::new(context.clone());
+        new_context.update(kind, namespace);
+
+        Self {
+            current_context: Some(context),
+            contexts: vec![new_context],
+        }
+    }
+}
+
+/// Application history.
+#[derive(Serialize, Deserialize, Default, Clone)]
+pub struct History {
+    pub kube_configs: HashMap<String, KubeConfig>,
+    #[serde(skip_serializing)]
+    current_kube_config: Option<String>,
+    #[serde(skip_serializing)]
+    current_hash: Option<String>,
+}
+
+impl History {
+    /// Returns watcher for history.
+    pub fn watcher() -> ConfigWatcher<History> {
+        ConfigWatcher::new(get_default_history_dir())
+    }
+
+    /// Loads history from a file or creates default one if the file does not exist.
+    /// Default location for the history file is: `HOME/b4n/history.yaml`.
+    pub async fn load_or_create() -> Result<Self, ConfigError> {
+        let history = Self::load().await;
+        match history {
+            Ok(history) => Ok(history),
+            Err(ConfigError::SerializationError(_)) => Ok(Self::default()),
+            Err(_) => {
+                let history = Self::default();
+                history.save().await?;
+                Ok(history)
+            }
+        }
+    }
+
+    /// Returns a kind stored in the history under a specific context name.
+    pub fn get_kind(&self, context: &str) -> Option<&str> {
+        if let Some(index) = self.context_index(context) {
+            Some(&self.kube_configs[self.config_key()].contexts[index].kind)
+        } else {
+            None
+        }
+    }
+
+    /// Returns a namespace stored in the history under a specific context name.
+    pub fn get_namespace(&self, context: &str) -> Option<&str> {
+        if let Some(index) = self.context_index(context) {
+            Some(&self.kube_configs[self.config_key()].contexts[index].namespace)
+        } else {
+            None
+        }
+    }
+
+    /// Gets the currently used kube config path.
+    pub fn kube_config_path(&self) -> Option<&str> {
+        self.current_kube_config.as_deref()
+    }
+
+    /// Sets the currently used kube config path.
+    pub fn set_kube_config_path(&mut self, path: Option<String>) {
+        if let Some(path) = path {
+            self.current_hash = Some(calculate_hash(&path, 8));
+            self.current_kube_config = Some(path);
+        } else {
+            self.current_hash = None;
+            self.current_kube_config = None;
+        }
+    }
+
+    /// Returns currently selected context name.
+    pub fn current_context(&self) -> Option<&str> {
+        self.current_config().and_then(|c| c.current_context.as_deref())
+    }
+
+    /// Creates or updates (if exists) context data.
+    pub fn create_or_update_context(&mut self, context: String, kind: Option<String>, namespace: Option<String>) {
+        if let Some(config) = self.current_config_mut() {
+            if let Some(index) = config.contexts.iter().position(|c| c.name == context) {
+                config.contexts[index].update(kind, namespace);
+            } else {
+                let mut context = ContextInfo::new(context.clone());
+                context.update(kind, namespace);
+                config.contexts.push(context);
+            }
+
+            config.current_context = Some(context);
+        } else {
+            self.kube_configs
+                .insert(self.config_key().to_owned(), KubeConfig::new(context, kind, namespace));
+        }
+    }
+
+    fn config_key(&self) -> &str {
+        match &self.current_hash {
+            Some(hash) => hash,
+            None => "default",
+        }
+    }
+
+    fn context_index(&self, context: &str) -> Option<usize> {
+        self.kube_configs
+            .get(self.config_key())
+            .and_then(|c| c.contexts.iter().position(|c| c.name == context))
+    }
+
+    fn current_config(&self) -> Option<&KubeConfig> {
+        self.kube_configs.get(self.config_key())
+    }
+
+    fn current_config_mut(&mut self) -> Option<&mut KubeConfig> {
+        let current_key = match &self.current_hash {
+            Some(hash) => hash,
+            None => "default",
+        };
+
+        self.kube_configs.get_mut(current_key)
+    }
+}
+
+impl Persistable<History> for History {
+    async fn load() -> Result<History, ConfigError> {
+        let mut file = File::open(get_default_history_dir()).await?;
+
+        let mut history_str = String::new();
+        file.read_to_string(&mut history_str).await?;
+
+        Ok(serde_yaml::from_str::<History>(&history_str)?)
+    }
+
+    async fn save(&self) -> Result<(), ConfigError> {
+        let history_str = serde_yaml::to_string(self)?;
+
+        let mut file = File::create(get_default_history_dir()).await?;
+        file.write_all(history_str.as_bytes()).await?;
+        file.flush().await?;
+
+        Ok(())
+    }
+}
+
+fn get_default_history_dir() -> PathBuf {
+    match home::home_dir() {
+        Some(path) => path.join(format!(".{}", env!("CARGO_CRATE_NAME"))).join("history.yaml"),
+        None => PathBuf::from("history.yaml"),
+    }
+}

--- a/src/app/configuration/history.rs
+++ b/src/app/configuration/history.rs
@@ -16,6 +16,7 @@ pub struct ContextInfo {
     pub name: String,
     pub namespace: String,
     pub kind: String,
+    pub filter_history: Vec<String>,
 }
 
 impl ContextInfo {
@@ -33,6 +34,7 @@ impl ContextInfo {
             name: info.context.clone(),
             namespace: info.namespace.as_str().into(),
             kind: info.kind.clone(),
+            filter_history: Vec::new(),
         }
     }
 
@@ -153,6 +155,26 @@ impl History {
         } else {
             self.kube_configs
                 .insert(self.config_key().to_owned(), KubeConfig::new(context, kind, namespace));
+        }
+    }
+
+    /// Gets copy of `filter_history` from the specified `context` of the current kube config.
+    pub fn get_filter_history(&mut self, context: &str) -> Vec<String> {
+        if let Some(config) = self.current_config_mut() {
+            if let Some(index) = config.contexts.iter().position(|c| c.name == context) {
+                return config.contexts[index].filter_history.clone();
+            }
+        }
+
+        Vec::new()
+    }
+
+    /// Updates `filter_history` in the specified `context` of the current kube config.
+    pub fn update_filter_history(&mut self, context: &str, filter_history: Vec<String>) {
+        if let Some(config) = self.current_config_mut() {
+            if let Some(index) = config.contexts.iter().position(|c| c.name == context) {
+                config.contexts[index].filter_history = filter_history;
+            }
         }
     }
 

--- a/src/app/configuration/mod.rs
+++ b/src/app/configuration/mod.rs
@@ -1,5 +1,7 @@
 pub use self::config::*;
+pub use self::history::*;
 pub use self::watcher::*;
 
 mod config;
+mod history;
 mod watcher;

--- a/src/app/lists/column.rs
+++ b/src/app/lists/column.rs
@@ -113,6 +113,23 @@ impl Column {
         self
     }
 
+    /// Returns the current length of a [`Column`].
+    #[inline]
+    pub fn len(&self) -> usize {
+        if self.is_fixed {
+            self.data_len
+        } else {
+            self.data_len.clamp(self.min_len(), self.max_len())
+        }
+    }
+
+    /// Returns `true` if [`Column`] has a current length of zero bytes.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Returns `min` length of a [`Column`].
     #[inline]
     pub fn min_len(&self) -> usize {
         if self.is_sorted && self.name.chars().count() + 1 > self.min_len {
@@ -122,6 +139,7 @@ impl Column {
         }
     }
 
+    /// Returns `max` length of a [`Column`].
     #[inline]
     pub fn max_len(&self) -> usize {
         if self.is_sorted && self.min_len() > self.max_len {

--- a/src/app/lists/filter/filterable_list.rs
+++ b/src/app/lists/filter/filterable_list.rs
@@ -18,18 +18,15 @@ mod filterable_list_tests;
 pub struct FilterableList<T: Filterable<Fc>, Fc: FilterContext> {
     items: Vec<T>,
     filtered: Option<Vec<usize>>,
-    len: usize,
     _marker: PhantomData<Fc>,
 }
 
 impl<T: Filterable<Fc>, Fc: FilterContext> FilterableList<T, Fc> {
     /// Creates new [`FilterableList<T, Fc>`] instance from the [`Vec`] object.
     pub fn from(items: Vec<T>) -> Self {
-        let len = items.len();
         Self {
             items,
             filtered: None,
-            len,
             _marker: PhantomData,
         }
     }
@@ -64,7 +61,6 @@ impl<T: Filterable<Fc>, Fc: FilterContext> FilterableList<T, Fc> {
             .filter(|(_i, x)| x.is_matching(context))
             .map(|(i, _x)| i)
             .collect();
-        self.len = filtered.len();
         self.filtered = Some(filtered);
     }
 
@@ -72,19 +68,21 @@ impl<T: Filterable<Fc>, Fc: FilterContext> FilterableList<T, Fc> {
     #[inline]
     pub fn filter_reset(&mut self) {
         self.filtered = None;
-        self.len = self.items.len();
     }
 
     /// Returns the number of elements in the filtered out list.
     #[inline]
     pub fn len(&self) -> usize {
-        self.len
+        match &self.filtered {
+            Some(filtered) => filtered.len(),
+            None => self.items.len(),
+        }
     }
 
     /// Returns `true` if the filtered out list contains no elements.
     #[inline]
     pub fn is_empty(&self) -> bool {
-        self.len == 0
+        self.len() == 0
     }
 
     /// Inserts an element at position `index` within the vector, shifting all elements after it to the right.  

--- a/src/app/lists/scrollable_list.rs
+++ b/src/app/lists/scrollable_list.rs
@@ -65,7 +65,7 @@ impl<T: Row + Filterable<Fc>, Fc: FilterContext> ScrollableList<T, Fc> {
         }
     }
 
-    /// Returns the number of elements in the scrollable list.
+    /// Returns the number of elements in the filtered out scrollable list.
     pub fn len(&self) -> usize {
         self.items.as_ref().map(|l| l.len()).unwrap_or_default()
     }

--- a/src/app/managers/client.rs
+++ b/src/app/managers/client.rs
@@ -148,7 +148,7 @@ impl KubernetesClientManager {
 
     /// Sends command to create new Kubernetes client to the background executor.
     fn new_kubernetes_client(&mut self, context: String, kind: String, namespace: Namespace) -> RequestInfo {
-        let kube_config_path = self.app_data.borrow().config.kube_config_path().map(String::from);
+        let kube_config_path = self.app_data.borrow().history.kube_config_path().map(String::from);
         let cmd = NewKubernetesClientCommand::new(kube_config_path, context.clone(), kind.clone(), namespace.clone());
 
         RequestInfo {

--- a/src/app/tasks/task.rs
+++ b/src/app/tasks/task.rs
@@ -95,6 +95,7 @@ async fn run_command(command: Command) -> Option<CommandResult> {
         Command::ListKubeContexts(command) => command.execute().await,
         Command::NewKubernetesClient(command) => command.execute().await,
         Command::SaveConfiguration(command) => command.execute().await,
+        Command::SaveHistory(command) => command.execute().await,
         Command::DeleteResource(command) => command.execute().await,
         Command::GetYaml(command) => command.execute().await,
     }

--- a/src/app/worker.rs
+++ b/src/app/worker.rs
@@ -13,8 +13,8 @@ use crate::{
 };
 
 use super::{
-    BgDiscovery, BgExecutor, BgObserver, BgObserverError, Config, SyntaxData, TaskResult,
-    commands::{Command, DeleteResourcesCommand, GetResourceYamlCommand, SaveConfigurationCommand},
+    BgDiscovery, BgExecutor, BgObserver, BgObserverError, Config, History, SyntaxData, TaskResult,
+    commands::{Command, DeleteResourcesCommand, GetResourceYamlCommand, SaveConfigurationCommand, SaveHistoryCommand},
 };
 
 pub type SharedBgWorker = Rc<RefCell<BgWorker>>;
@@ -152,10 +152,16 @@ impl BgWorker {
         }
     }
 
-    /// Saves the provided configuration to a file.
+    /// Saves the provided app configuration to a file.
     pub fn save_configuration(&mut self, config: Config) {
         self.executor
             .run_task(Command::SaveConfiguration(Box::new(SaveConfigurationCommand::new(config))));
+    }
+
+    /// Saves the provided app history to a file.
+    pub fn save_history(&mut self, history: History) {
+        self.executor
+            .run_task(Command::SaveHistory(Box::new(SaveHistoryCommand::new(history))));
     }
 
     /// Sends [`DeleteResourcesCommand`] to the background executor with provided resource names.  

--- a/src/kubernetes/resources/data/config_map.rs
+++ b/src/kubernetes/resources/data/config_map.rs
@@ -1,0 +1,32 @@
+use kube::api::DynamicObject;
+use std::rc::Rc;
+
+use crate::{
+    app::lists::{Column, Header, NAMESPACE},
+    kubernetes::resources::{ResourceData, ResourceValue},
+};
+
+/// Returns [`ResourceData`] for the `config_map` kubernetes resource.
+pub fn data(object: &DynamicObject) -> ResourceData {
+    let data_count = object.data["data"].as_object().map(|o| o.len()).unwrap_or(0).to_string();
+    let is_terminating = object.metadata.deletion_timestamp.is_some();
+
+    let values: [ResourceValue; 1] = [ResourceValue::numeric(Some(data_count), 5)];
+
+    ResourceData {
+        extra_values: Box::new(values),
+        is_job: false,
+        is_completed: false,
+        is_ready: !is_terminating,
+        is_terminating,
+    }
+}
+
+/// Returns [`Header`] for the `config_map` kubernetes resource.
+pub fn header() -> Header {
+    Header::from(
+        NAMESPACE.clone(),
+        Some(Box::new([Column::fixed("DATA", 5, true)])),
+        Rc::new([' ', 'N', 'D', 'A']),
+    )
+}

--- a/src/kubernetes/resources/data/mod.rs
+++ b/src/kubernetes/resources/data/mod.rs
@@ -5,14 +5,20 @@ use crate::{
     ui::{colors::TextColors, theme::Theme},
 };
 
+pub mod config_map;
 pub mod default;
+pub mod namespace;
 pub mod pod;
+pub mod secret;
 pub mod service;
 
 /// Returns [`ResourceData`] for provided Kubernetes resource.
 pub fn get_resource_data(kind: &str, object: &DynamicObject) -> ResourceData {
     match kind {
+        "ConfigMap" => config_map::data(object),
+        "Namespace" => namespace::data(object),
         "Pod" => pod::data(object),
+        "Secret" => secret::data(object),
         "Service" => service::data(object),
         _ => default::data(object),
     }
@@ -21,7 +27,10 @@ pub fn get_resource_data(kind: &str, object: &DynamicObject) -> ResourceData {
 /// Returns [`Header`] for provided Kubernetes resource kind.
 pub fn get_header_data(kind: &str) -> Header {
     match kind {
+        "ConfigMap" => config_map::header(),
+        "Namespace" => namespace::header(),
         "Pod" => pod::header(),
+        "Secret" => secret::header(),
         "Service" => service::header(),
         _ => default::header(),
     }
@@ -43,6 +52,15 @@ impl ResourceValue {
             text,
             number: numeric,
             is_numeric: true,
+        }
+    }
+
+    /// Returns resource value.
+    pub fn value(&self) -> &str {
+        if self.is_numeric {
+            self.number.as_deref().unwrap_or("NaN")
+        } else {
+            self.text.as_deref().unwrap_or("n/a")
         }
     }
 }

--- a/src/kubernetes/resources/data/namespace.rs
+++ b/src/kubernetes/resources/data/namespace.rs
@@ -1,0 +1,33 @@
+use kube::api::DynamicObject;
+use std::rc::Rc;
+
+use crate::{
+    app::lists::{Column, Header, NAMESPACE},
+    kubernetes::resources::{ResourceData, ResourceValue},
+};
+
+/// Returns [`ResourceData`] for the `namespace` kubernetes resource.
+pub fn data(object: &DynamicObject) -> ResourceData {
+    let status = &object.data["status"];
+    let phase = status["phase"].as_str().map(|s| s.to_owned());
+    let is_terminating = object.metadata.deletion_timestamp.is_some();
+
+    let values: [ResourceValue; 1] = [if is_terminating { "Terminating".into() } else { phase.into() }];
+
+    ResourceData {
+        extra_values: Box::new(values),
+        is_job: false,
+        is_completed: false,
+        is_ready: !is_terminating,
+        is_terminating,
+    }
+}
+
+/// Returns [`Header`] for the `namespace` kubernetes resource.
+pub fn header() -> Header {
+    Header::from(
+        NAMESPACE.clone(),
+        Some(Box::new([Column::bound("STATUS", 10, 20, false)])),
+        Rc::new([' ', 'N', 'S', 'A']),
+    )
+}

--- a/src/kubernetes/resources/data/secret.rs
+++ b/src/kubernetes/resources/data/secret.rs
@@ -1,0 +1,36 @@
+use kube::api::DynamicObject;
+use std::rc::Rc;
+
+use crate::{
+    app::lists::{Column, Header, NAMESPACE},
+    kubernetes::resources::{ResourceData, ResourceValue},
+};
+
+/// Returns [`ResourceData`] for the `secret` kubernetes resource.
+pub fn data(object: &DynamicObject) -> ResourceData {
+    let secret_type = object.data["type"].as_str().map(|t| t.to_owned());
+    let data_count = object.data["data"].as_object().map(|o| o.len()).unwrap_or(0).to_string();
+    let is_terminating = object.metadata.deletion_timestamp.is_some();
+
+    let values: [ResourceValue; 2] = [secret_type.into(), ResourceValue::numeric(Some(data_count), 5)];
+
+    ResourceData {
+        extra_values: Box::new(values),
+        is_job: false,
+        is_completed: false,
+        is_ready: !is_terminating,
+        is_terminating,
+    }
+}
+
+/// Returns [`Header`] for the `secret` kubernetes resource.
+pub fn header() -> Header {
+    Header::from(
+        NAMESPACE.clone(),
+        Some(Box::new([
+            Column::bound("TYPE", 8, 25, false),
+            Column::fixed("DATA", 5, true),
+        ])),
+        Rc::new([' ', 'N', 'T', 'D', 'A']),
+    )
+}

--- a/src/kubernetes/resources/resource.rs
+++ b/src/kubernetes/resources/resource.rs
@@ -96,7 +96,7 @@ impl Resource {
                 .as_ref()
                 .map(kubernetes::utils::format_timestamp)
                 .as_deref()
-                .unwrap_or(" "),
+                .unwrap_or("n/a"),
             AGE_COLUMN_WIDTH + 1,
             true,
         );

--- a/src/kubernetes/resources/resource.rs
+++ b/src/kubernetes/resources/resource.rs
@@ -96,7 +96,7 @@ impl Resource {
                 .as_ref()
                 .map(kubernetes::utils::format_timestamp)
                 .as_deref()
-                .unwrap_or("n/a"),
+                .unwrap_or(" "),
             AGE_COLUMN_WIDTH + 1,
             true,
         );
@@ -109,28 +109,33 @@ impl Resource {
     }
 
     fn push_inner_text(&self, row: &mut String, header: &Header) {
-        let Some(values) = self.get_extra_values() else {
-            return;
-        };
         let Some(columns) = header.get_extra_columns() else {
             return;
         };
-        if values.len() != columns.len() {
-            return;
-        }
-
-        for i in 0..columns.len() {
-            if i > 0 {
-                row.push(' ');
+        if let Some(values) = self.get_extra_values() {
+            if values.len() != columns.len() {
+                return;
             }
 
-            let len = if columns[i].is_fixed {
-                columns[i].data_len
-            } else {
-                columns[i].data_len.clamp(columns[i].min_len(), columns[i].max_len())
-            };
+            for i in 0..columns.len() {
+                if i > 0 {
+                    row.push(' ');
+                }
 
-            row.push_cell(values[i].text.as_deref().unwrap_or("n/a"), len, columns[i].to_right);
+                row.push_cell(
+                    values[i].text.as_deref().unwrap_or("n/a"),
+                    columns[i].len(),
+                    columns[i].to_right,
+                );
+            }
+        } else {
+            for (i, column) in columns.iter().enumerate() {
+                if i > 0 {
+                    row.push(' ');
+                }
+
+                (0..column.len()).for_each(|_| row.push(' '));
+            }
         }
     }
 
@@ -182,11 +187,7 @@ impl Row for Resource {
     fn column_sort_text(&self, column: usize) -> &str {
         if let Some(values) = self.get_extra_values() {
             if column >= 2 && column <= values.len() + 1 {
-                if values[column - 2].is_numeric {
-                    return values[column - 2].number.as_deref().unwrap_or("n/a");
-                } else {
-                    return values[column - 2].text.as_deref().unwrap_or("n/a");
-                }
+                return values[column - 2].value();
             }
         }
 

--- a/src/ui/views/resources/view.rs
+++ b/src/ui/views/resources/view.rs
@@ -9,7 +9,7 @@ use std::{collections::HashMap, rc::Rc};
 
 use crate::{
     app::{
-        ObserverResult, SharedAppData,
+        ObserverResult, SharedAppData, SharedBgWorker,
         lists::{KindsList, ResourcesList},
     },
     kubernetes::{
@@ -38,7 +38,7 @@ pub struct ResourcesView {
 
 impl ResourcesView {
     /// Creates a new resources view.
-    pub fn new(app_data: SharedAppData) -> Self {
+    pub fn new(app_data: SharedAppData, worker: SharedBgWorker) -> Self {
         let table = ResourcesTable::new(Rc::clone(&app_data));
         let ns_selector = SideSelect::new(
             "NAMESPACE",
@@ -56,7 +56,7 @@ impl ResourcesView {
             ResponseEvent::ChangeKind,
             35,
         );
-        let filter = Filter::new(Rc::clone(&app_data), 60);
+        let filter = Filter::new(Rc::clone(&app_data), Some(worker), 60);
 
         Self {
             app_data,

--- a/src/ui/widgets/filters/filter.rs
+++ b/src/ui/widgets/filters/filter.rs
@@ -6,24 +6,24 @@ use ratatui::{
 };
 
 use crate::{
-    app::SharedAppData,
+    app::{SharedAppData, SharedBgWorker},
     ui::{ResponseEvent, Responsive, Table, utils::center_horizontal, widgets::Select},
     utils::logical_expressions::{ParserError, validate},
 };
 
 use super::PatternsList;
 
-const HISTORY_SIZE: usize = 10;
+const HISTORY_SIZE: usize = 20;
 
 #[cfg(test)]
 #[path = "./filter.tests.rs"]
 mod filter_tests;
 
 /// Filter widget for TUI.
-#[derive(Default)]
 pub struct Filter {
     pub is_visible: bool,
     app_data: SharedAppData,
+    worker: Option<SharedBgWorker>,
     patterns: Select<PatternsList>,
     current: String,
     last_validated: String,
@@ -32,17 +32,20 @@ pub struct Filter {
 
 impl Filter {
     /// Creates new [`Filter`] instance.
-    pub fn new(app_data: SharedAppData, width: u16) -> Self {
+    pub fn new(app_data: SharedAppData, worker: Option<SharedBgWorker>, width: u16) -> Self {
         let colors = app_data.borrow().config.theme.colors.filter.clone();
         let patterns = Select::new(PatternsList::default(), colors, false, true)
             .with_prompt(" ")
             .with_accent_characters("|&!()");
 
         Self {
+            is_visible: false,
             app_data,
+            worker,
             patterns,
+            current: String::new(),
+            last_validated: String::new(),
             width,
-            ..Default::default()
         }
     }
 
@@ -53,6 +56,11 @@ impl Filter {
 
     /// Marks [`Filter`] as visible.
     pub fn show(&mut self) {
+        let context = self.app_data.borrow().current.context.clone();
+        self.patterns.items = PatternsList::from(self.app_data.borrow_mut().history.get_filter_history(&context));
+        self.patterns.update_items_filter();
+        self.patterns
+            .set_colors(self.app_data.borrow().config.theme.colors.filter.clone());
         self.is_visible = true;
     }
 
@@ -99,10 +107,28 @@ impl Filter {
         self.last_validated = self.patterns.value().to_owned();
     }
 
-    fn remember_pattern(&mut self, pattern: String) {
-        self.current = pattern.clone();
-        if !pattern.is_empty() && !self.patterns.items.contains(&pattern) && self.patterns.items.len() < HISTORY_SIZE {
-            self.patterns.items.list.push(pattern.into());
+    fn remember_pattern(&mut self) {
+        let pattern = self.patterns.value();
+        self.current = pattern.to_owned();
+        if !pattern.is_empty() && !self.patterns.items.contains(pattern) {
+            self.patterns.items.list.push(pattern.to_owned().into());
+
+            let len = self.patterns.items.list.items.as_ref().map(|l| l.full_len());
+            if len.unwrap_or_default() > HISTORY_SIZE {
+                self.patterns.items.remove_oldest();
+            }
+
+            self.patterns.items.list.sort(1, false);
+
+            let context = self.app_data.borrow().current.context.clone();
+            self.app_data
+                .borrow_mut()
+                .history
+                .update_filter_history(&context, self.patterns.items.get_filter_history());
+
+            if let Some(worker) = &self.worker {
+                worker.borrow_mut().save_history(self.app_data.borrow().history.clone());
+            }
         }
     }
 }
@@ -130,7 +156,8 @@ impl Responsive for Filter {
             }
 
             self.is_visible = false;
-            self.remember_pattern(self.patterns.value().to_owned());
+            self.remember_pattern();
+
             return ResponseEvent::Handled;
         }
 

--- a/src/ui/widgets/filters/filter.tests.rs
+++ b/src/ui/widgets/filters/filter.tests.rs
@@ -7,7 +7,7 @@ use super::*;
 #[test]
 fn esc_reverts_value_test() {
     let data = Rc::new(RefCell::new(AppData::default()));
-    let mut filter = Filter::new(data, 60);
+    let mut filter = Filter::new(data, None, 60);
 
     filter.show();
     filter.process_key(KeyEvent::from(KeyCode::Char('t')));
@@ -25,7 +25,7 @@ fn esc_reverts_value_test() {
 #[test]
 fn enter_stores_value_test() {
     let data = Rc::new(RefCell::new(AppData::default()));
-    let mut filter = Filter::new(data, 60);
+    let mut filter = Filter::new(data, None, 60);
 
     filter.show();
     filter.process_key(KeyEvent::from(KeyCode::Char('t')));

--- a/src/ui/widgets/filters/pattern.rs
+++ b/src/ui/widgets/filters/pattern.rs
@@ -1,17 +1,54 @@
+use std::time::{Duration, SystemTime};
+
 use crate::{
     app::lists::{BasicFilterContext, Filterable, Row},
     utils::{add_padding, truncate},
 };
 
 /// Filter pattern item.
-#[derive(Default)]
 pub struct Pattern {
     pub value: String,
+    pub creation_time: SystemTime,
+}
+
+impl Default for Pattern {
+    fn default() -> Self {
+        Self {
+            value: Default::default(),
+            creation_time: SystemTime::now(),
+        }
+    }
+}
+
+impl std::fmt::Display for Pattern {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "{}::{}",
+            self.value,
+            self.creation_time
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .map(|d| d.as_secs())
+                .unwrap_or(0)
+        )
+    }
 }
 
 impl From<String> for Pattern {
     fn from(value: String) -> Self {
-        Self { value }
+        if value.contains("::") {
+            let mut split = value.splitn(2, "::");
+            Self {
+                value: split.next().map(String::from).unwrap(),
+                creation_time: SystemTime::UNIX_EPOCH
+                    + Duration::from_secs(split.next().map(|d| d.parse::<u64>().unwrap_or(0)).unwrap_or(0)),
+            }
+        } else {
+            Self {
+                value,
+                creation_time: SystemTime::now(),
+            }
+        }
     }
 }
 

--- a/src/ui/widgets/filters/patterns_list.rs
+++ b/src/ui/widgets/filters/patterns_list.rs
@@ -15,12 +15,42 @@ pub struct PatternsList {
 }
 
 impl PatternsList {
+    /// Creates new [`PatternsList`] instance from the filter history list.
+    pub fn from(filter_history: Vec<String>) -> Self {
+        let mut list = ScrollableList::from(filter_history.into_iter().map(Pattern::from).collect());
+        list.sort(1, false);
+        Self { list }
+    }
+
     /// Returns `true` if the [`PatternsList`] contains an element with the given value.
     pub fn contains(&self, value: &str) -> bool {
         self.list
             .items
             .as_ref()
             .is_some_and(|l| l.full_iter().any(|i| i.data.value == value))
+    }
+
+    /// Removes the oldest element from a list.
+    pub fn remove_oldest(&mut self) {
+        if let Some(list) = &mut self.list.items {
+            let index = list
+                .full_iter()
+                .enumerate()
+                .min_by_key(|(_, i)| i.data.creation_time)
+                .map(|(index, _)| index);
+            if let Some(index) = index {
+                list.full_remove(index);
+            }
+        }
+    }
+
+    /// Returns [`PatternsList`] as a filter history that can be saved in the app history data.
+    pub fn get_filter_history(&self) -> Vec<String> {
+        if let Some(list) = &self.list.items {
+            list.full_iter().map(|i| i.data.to_string()).collect()
+        } else {
+            Vec::new()
+        }
     }
 }
 

--- a/src/ui/widgets/select.rs
+++ b/src/ui/widgets/select.rs
@@ -114,15 +114,8 @@ impl<T: Table> Select<T> {
         }
     }
 
-    fn filter_and_highlight(&mut self) {
-        self.items.filter(Some(self.filter.value().to_owned()));
-        self.items.highlight_item_by_name_start(self.filter.value());
-        if self.items.get_highlighted_item_index().is_none() {
-            self.items.highlight_first_item();
-        }
-    }
-
-    fn update_items_filter(&mut self) {
+    /// Updates filter applied on items.
+    pub fn update_items_filter(&mut self) {
         if self.filter.value().is_empty() {
             self.items.filter(None);
         } else if let Some(filter) = self.items.get_filter() {
@@ -131,6 +124,14 @@ impl<T: Table> Select<T> {
             }
         } else {
             self.filter_and_highlight();
+        }
+    }
+
+    fn filter_and_highlight(&mut self) {
+        self.items.filter(Some(self.filter.value().to_owned()));
+        self.items.highlight_item_by_name_start(self.filter.value());
+        if self.items.get_highlighted_item_index().is_none() {
+            self.items.highlight_first_item();
         }
     }
 }


### PR DESCRIPTION
Adds a separate `history.yaml` file for application history, such as the selected resource in the context or the applied filters.