### PR TITLE
Extend logs view functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Change Log
 
+## 0.1.4 - 2025-04-08
+
+### Features
+
+- toggle timestamps in logs by pressing `t`
+- add views for the following resource types: DaemonSets, Deployments, Events, Jobs, ReplicaSets and StatefulSets
+
+### Bug fixes
+
+- ensure the resource group is respected in the YAML view and during resource deletion
+
 ## 0.1.3 - 2025-04-04
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,7 +154,7 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "b4n"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "backoff",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,9 +305,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.17"
+version = "1.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fcb57c740ae1daf453ae85f16e37396f672b039e00d9d866e07ddb24e328e3a"
+checksum = "525046617d8376e3db1deffb079e91cef90a89fc3ca5c185bbf8c9ecdd15cd5c"
 dependencies = [
  "shlex",
 ]
@@ -563,9 +563,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.4.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cfac68e08048ae1883171632c2aef3ebc555621ae56fbccce1cbf22dd7f058"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
 dependencies = [
  "powerfmt",
 ]
@@ -653,9 +653,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
@@ -1098,9 +1098,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "indexmap"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -1455,9 +1455,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.5"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
+checksum = "ff70ce3e48ae43fa075863cef62e8b43b71a4f2382229920e0df362592919430"
 dependencies = [
  "adler2",
 ]
@@ -1884,9 +1884,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.10"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b8c0c260b63a8219631167be35e6a988e9554dbd323f8bd08439c8ed1302bd1"
+checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
 dependencies = [
  "bitflags 2.9.0",
 ]
@@ -2345,9 +2345,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
+checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
 name = "smawk"
@@ -2540,9 +2540,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.44.1"
+version = "1.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f382da615b842244d4b8738c82ed1275e6c5dd90c459a30941cd07080b06c91a"
+checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
 dependencies = [
  "backtrace",
  "bytes",
@@ -3074,9 +3074,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e97b544156e9bebe1a0ffbc03484fc1ffe3100cbce3ffb17eac35f7cdd7ab36"
+checksum = "63d3fcd9bba44b03821e7d699eeee959f3126dcc4aa8e4ae18ec617c2a5cea10"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "b4n"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ General planned features:
 | Quit the application                    | `CTRL` + `c`    |                                                              |
 | Reverse selection                       | `CTRL` + ` `    |  (`CTRL` + `SPACE`)                                          |
 | Select resource                         | ` `             | (`SPACE`)                                                    |
-| Show / hide log timestams               | `t`             | works only in logs view                                      |
+| Show / hide log timestamps              | `t`             | Works only in logs view                                      |
 | Show command palette                    | `:`             | For example, entering `:q`↲ quits the app                    |
 | Show filter input                       | `/`             | Possible operators: and `&`, or `\|`, negation `!`, `(`, `)` |
 | Show logs for the highlighted container | `l`             | Press `p` to display previous logs for the container         |

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ General planned features:
 | Quit the application                    | `CTRL` + `c`    |                                                              |
 | Reverse selection                       | `CTRL` + ` `    |  (`CTRL` + `SPACE`)                                          |
 | Select resource                         | ` `             | (`SPACE`)                                                    |
+| Show / hide log timestams               | `t`             | works only in logs view                                      |
 | Show command palette                    | `:`             | For example, entering `:q`↲ quits the app                    |
 | Show filter input                       | `/`             | Possible operators: and `&`, or `\|`, negation `!`, `(`, `)` |
 | Show logs for the highlighted container | `l`             | Press `p` to display previous logs for the container         |

--- a/src/app/app.rs
+++ b/src/app/app.rs
@@ -321,7 +321,7 @@ impl App {
             };
             self.worker
                 .borrow_mut()
-                .delete_resources(resources, namespace, self.resources.kind_plural());
+                .delete_resources(resources, namespace, &self.resources.get_kind_with_group());
         }
 
         self.resources.deselect_all();
@@ -384,7 +384,7 @@ impl App {
         let command_id = self.worker.borrow_mut().get_yaml(
             resource.clone(),
             namespace.clone().into(),
-            self.resources.kind_plural(),
+            &self.resources.get_kind_with_group(),
             self.data.borrow().get_syntax_data(),
             decode,
         );

--- a/src/app/data.rs
+++ b/src/app/data.rs
@@ -68,11 +68,12 @@ impl ResourcesInfo {
 
     /// Returns `true` if specified `kind` is equal to the currently held by [`ResourcesInfo`].
     pub fn is_kind_equal(&self, kind: &str) -> bool {
-        if self.kind_plural == kind || self.kind.to_lowercase() == kind {
-            return true;
+        if kind.contains('.') {
+            let (kind, group) = kind.split_once('.').unwrap();
+            (self.kind_plural == kind || self.kind.to_lowercase() == kind) && self.group == group
+        } else {
+            (self.kind_plural == kind || self.kind.to_lowercase() == kind) && self.group.is_empty()
         }
-
-        kind.contains('.') && format!("{}.{}", self.kind_plural, self.group) == kind
     }
 
     /// Returns `true` if specified `namespace` is equal to the currently held by [`ResourcesInfo`].  

--- a/src/app/observer.rs
+++ b/src/app/observer.rs
@@ -423,7 +423,7 @@ impl EventsProcessor {
     }
 
     fn send_containers(&self, object: &DynamicObject, array: &str, statuses_array: &str, is_init: bool, is_delete: bool) {
-        if let Some(containers) = get_conatainers(object, array) {
+        if let Some(containers) = get_containers(object, array) {
             for c in containers.iter() {
                 let result = get_container_result(c, object, statuses_array, is_init, is_delete);
                 self.context_tx.send(Box::new(result)).unwrap();
@@ -437,7 +437,7 @@ impl EventsProcessor {
     }
 }
 
-fn get_conatainers<'a>(object: &'a DynamicObject, array_name: &str) -> Option<&'a Vec<Value>> {
+fn get_containers<'a>(object: &'a DynamicObject, array_name: &str) -> Option<&'a Vec<Value>> {
     object
         .data
         .get("spec")

--- a/src/kubernetes/resources/data/daemon_set.rs
+++ b/src/kubernetes/resources/data/daemon_set.rs
@@ -1,0 +1,49 @@
+use kube::api::DynamicObject;
+use std::rc::Rc;
+
+use crate::{
+    app::lists::{Column, Header, NAMESPACE},
+    kubernetes::resources::{ResourceData, ResourceValue},
+};
+
+/// Returns [`ResourceData`] for the `daemonset` kubernetes resource.
+pub fn data(object: &DynamicObject) -> ResourceData {
+    let status = &object.data["status"];
+    let desired = status["desiredNumberScheduled"].as_u64().unwrap_or_default();
+    let current = status["currentNumberScheduled"].as_u64().unwrap_or_default();
+    let ready = status["numberReady"].as_u64().unwrap_or_default();
+    let updated = status["updatedNumberScheduled"].as_u64().unwrap_or_default();
+    let available = status["numberAvailable"].as_u64().unwrap_or_default();
+    let is_terminating = object.metadata.deletion_timestamp.is_some();
+
+    let values: [ResourceValue; 5] = [
+        ResourceValue::numeric(Some(desired.to_string()), 5),
+        ResourceValue::numeric(Some(current.to_string()), 5),
+        ResourceValue::numeric(Some(ready.to_string()), 5),
+        ResourceValue::numeric(Some(updated.to_string()), 5),
+        ResourceValue::numeric(Some(available.to_string()), 5),
+    ];
+
+    ResourceData {
+        extra_values: Box::new(values),
+        is_job: false,
+        is_completed: false,
+        is_ready: !is_terminating,
+        is_terminating,
+    }
+}
+
+/// Returns [`Header`] for the `daemonset` kubernetes resource.
+pub fn header() -> Header {
+    Header::from(
+        NAMESPACE.clone(),
+        Some(Box::new([
+            Column::fixed("DESIRED", 3, true),
+            Column::fixed("CURRENT", 8, true),
+            Column::fixed("READY", 6, true),
+            Column::fixed("UPDATED", 8, true),
+            Column::fixed("AVAILABLE", 10, true),
+        ])),
+        Rc::new([' ', 'N', 'D', 'C', 'R', 'U', 'V', 'A']),
+    )
+}

--- a/src/kubernetes/resources/data/deployment.rs
+++ b/src/kubernetes/resources/data/deployment.rs
@@ -1,0 +1,44 @@
+use kube::api::DynamicObject;
+use std::rc::Rc;
+
+use crate::{
+    app::lists::{Column, Header, NAMESPACE},
+    kubernetes::resources::{ResourceData, ResourceValue},
+};
+
+/// Returns [`ResourceData`] for the `deployment` kubernetes resource.
+pub fn data(object: &DynamicObject) -> ResourceData {
+    let status = &object.data["status"];
+    let replicas = status["replicas"].as_u64().unwrap_or_default();
+    let ready = status["readyReplicas"].as_u64().unwrap_or_default();
+    let updated = status["updatedReplicas"].as_u64().unwrap_or_default();
+    let available = status["availableReplicas"].as_u64().unwrap_or_default();
+    let is_terminating = object.metadata.deletion_timestamp.is_some();
+
+    let values: [ResourceValue; 3] = [
+        format!("{}/{}", ready, replicas).into(),
+        format!("{}/{}", updated, replicas).into(),
+        format!("{}/{}", available, replicas).into(),
+    ];
+
+    ResourceData {
+        extra_values: Box::new(values),
+        is_job: false,
+        is_completed: false,
+        is_ready: !is_terminating,
+        is_terminating,
+    }
+}
+
+/// Returns [`Header`] for the `deployment` kubernetes resource.
+pub fn header() -> Header {
+    Header::from(
+        NAMESPACE.clone(),
+        Some(Box::new([
+            Column::fixed("READY", 6, true),
+            Column::fixed("UPDATED", 8, true),
+            Column::fixed("AVAILABLE", 10, true),
+        ])),
+        Rc::new([' ', 'N', 'R', 'U', 'V', 'A']),
+    )
+}

--- a/src/kubernetes/resources/data/event.rs
+++ b/src/kubernetes/resources/data/event.rs
@@ -1,0 +1,52 @@
+use kube::api::DynamicObject;
+use std::rc::Rc;
+
+use crate::{
+    app::lists::{Column, Header, NAMESPACE},
+    kubernetes::resources::{ResourceData, ResourceValue},
+};
+
+/// Returns [`ResourceData`] for the `event` kubernetes resource.
+pub fn data(object: &DynamicObject) -> ResourceData {
+    let count = object.data["count"].as_u64().unwrap_or_default();
+    let r#type = object.data["type"].as_str().map(|t| t.to_owned());
+    let reason = object.data["reason"].as_str().map(|t| t.to_owned());
+    let obj = &object.data["involvedObject"];
+    let kind = obj["kind"].as_str().unwrap_or_default().to_ascii_lowercase();
+    let name = obj["name"].as_str().unwrap_or_default();
+    let obj = if !kind.is_empty() || !name.is_empty() {
+        format!("{}/{}", kind, name)
+    } else {
+        "n/a".to_owned()
+    };
+    let is_terminating = object.metadata.deletion_timestamp.is_some();
+
+    let values: [ResourceValue; 4] = [
+        ResourceValue::numeric(Some(count.to_string()), 6),
+        r#type.into(),
+        reason.into(),
+        obj.into(),
+    ];
+
+    ResourceData {
+        extra_values: Box::new(values),
+        is_job: false,
+        is_completed: false,
+        is_ready: !is_terminating,
+        is_terminating,
+    }
+}
+
+/// Returns [`Header`] for the `event` kubernetes resource.
+pub fn header() -> Header {
+    Header::from(
+        NAMESPACE.clone(),
+        Some(Box::new([
+            Column::fixed("COUNT", 6, true),
+            Column::bound("TYPE", 6, 7, false),
+            Column::bound("REASON", 6, 25, false),
+            Column::bound("OBJECT", 15, 70, false),
+        ])),
+        Rc::new([' ', 'N', 'C', 'T', 'R', 'O', 'A']),
+    )
+}

--- a/src/kubernetes/resources/data/job.rs
+++ b/src/kubernetes/resources/data/job.rs
@@ -1,0 +1,44 @@
+use k8s_openapi::chrono::{DateTime, Utc};
+use kube::api::DynamicObject;
+use std::rc::Rc;
+
+use crate::{
+    app::lists::{Column, Header, NAMESPACE},
+    kubernetes::resources::{ResourceData, ResourceValue},
+};
+
+/// Returns [`ResourceData`] for the `job` kubernetes resource.
+pub fn data(object: &DynamicObject) -> ResourceData {
+    let status = &object.data["status"];
+    let succeeded = status["succeeded"].as_u64().unwrap_or_default();
+    let completions = object.data["spec"]["completions"].as_u64().unwrap_or_default();
+    let ctime: Option<DateTime<Utc>> = status["completionTime"].as_str().and_then(|t| t.parse().ok());
+    let stime: Option<DateTime<Utc>> = status["startTime"].as_str().and_then(|t| t.parse().ok());
+    let duration = ctime.and_then(|c| stime.map(|s| Utc::now() - (c - s)));
+    let is_terminating = object.metadata.deletion_timestamp.is_some();
+
+    let values: [ResourceValue; 2] = [
+        format!("{}/{}", succeeded, completions).into(),
+        ResourceValue::datetime(duration.as_ref()),
+    ];
+
+    ResourceData {
+        extra_values: Box::new(values),
+        is_job: false,
+        is_completed: false,
+        is_ready: !is_terminating,
+        is_terminating,
+    }
+}
+
+/// Returns [`Header`] for the `job` kubernetes resource.
+pub fn header() -> Header {
+    Header::from(
+        NAMESPACE.clone(),
+        Some(Box::new([
+            Column::fixed("COMPLETIONS", 7, true),
+            Column::fixed("DURATION", 9, true),
+        ])),
+        Rc::new([' ', 'N', 'C', 'D', 'A']),
+    )
+}

--- a/src/kubernetes/resources/data/replica_set.rs
+++ b/src/kubernetes/resources/data/replica_set.rs
@@ -1,0 +1,41 @@
+use kube::api::DynamicObject;
+use std::rc::Rc;
+
+use crate::{
+    app::lists::{Column, Header, NAMESPACE},
+    kubernetes::resources::{ResourceData, ResourceValue},
+};
+
+/// Returns [`ResourceData`] for the `replicaset` kubernetes resource.
+pub fn data(object: &DynamicObject) -> ResourceData {
+    let status = &object.data["status"];
+    let replicas = status["replicas"].as_u64().unwrap_or_default();
+    let ready = status["readyReplicas"].as_u64().unwrap_or_default();
+    let available = status["availableReplicas"].as_u64().unwrap_or_default();
+    let is_terminating = object.metadata.deletion_timestamp.is_some();
+
+    let values: [ResourceValue; 2] = [
+        format!("{}/{}", ready, replicas).into(),
+        format!("{}/{}", available, replicas).into(),
+    ];
+
+    ResourceData {
+        extra_values: Box::new(values),
+        is_job: false,
+        is_completed: false,
+        is_ready: !is_terminating,
+        is_terminating,
+    }
+}
+
+/// Returns [`Header`] for the `replicaset` kubernetes resource.
+pub fn header() -> Header {
+    Header::from(
+        NAMESPACE.clone(),
+        Some(Box::new([
+            Column::fixed("READY", 6, true),
+            Column::fixed("AVAILABLE", 10, true),
+        ])),
+        Rc::new([' ', 'N', 'R', 'V', 'A']),
+    )
+}

--- a/src/kubernetes/resources/data/stateful_set.rs
+++ b/src/kubernetes/resources/data/stateful_set.rs
@@ -1,0 +1,47 @@
+use kube::api::DynamicObject;
+use std::rc::Rc;
+
+use crate::{
+    app::lists::{Column, Header, NAMESPACE},
+    kubernetes::resources::{ResourceData, ResourceValue},
+};
+
+/// Returns [`ResourceData`] for the `statefulset` kubernetes resource.
+pub fn data(object: &DynamicObject) -> ResourceData {
+    let status = &object.data["status"];
+    let replicas = status["replicas"].as_u64().unwrap_or_default();
+    let ready = status["readyReplicas"].as_u64().unwrap_or_default();
+    let updated = status["updatedReplicas"].as_u64().unwrap_or_default();
+    let available = status["availableReplicas"].as_u64().unwrap_or_default();
+    let service = object.data["spec"]["serviceName"].as_str().map(String::from);
+    let is_terminating = object.metadata.deletion_timestamp.is_some();
+
+    let values: [ResourceValue; 4] = [
+        format!("{}/{}", ready, replicas).into(),
+        format!("{}/{}", updated, replicas).into(),
+        format!("{}/{}", available, replicas).into(),
+        service.into(),
+    ];
+
+    ResourceData {
+        extra_values: Box::new(values),
+        is_job: false,
+        is_completed: false,
+        is_ready: !is_terminating,
+        is_terminating,
+    }
+}
+
+/// Returns [`Header`] for the `statefulset` kubernetes resource.
+pub fn header() -> Header {
+    Header::from(
+        NAMESPACE.clone(),
+        Some(Box::new([
+            Column::fixed("READY", 6, true),
+            Column::fixed("UPDATED", 8, true),
+            Column::fixed("AVAILABLE", 10, true),
+            Column::bound("SERVICE", 8, 30, false),
+        ])),
+        Rc::new([' ', 'N', 'R', 'U', 'V', 'S', 'A']),
+    )
+}

--- a/src/kubernetes/utils.rs
+++ b/src/kubernetes/utils.rs
@@ -1,4 +1,7 @@
-use k8s_openapi::{apimachinery::pkg::apis::meta::v1::Time, chrono::Utc};
+use k8s_openapi::{
+    apimachinery::pkg::apis::meta::v1::Time,
+    chrono::{DateTime, Utc},
+};
 use kube::{
     ResourceExt,
     api::{ApiResource, DynamicObject},
@@ -18,8 +21,14 @@ pub fn serialize_resource(resource: &mut DynamicObject) -> Result<String, serde_
 }
 
 /// Formats kubernetes timestamp to a human-readable string.
+#[inline]
 pub fn format_timestamp(time: &Time) -> String {
-    let duration = Utc::now().signed_duration_since(time.0);
+    format_datetime(&time.0)
+}
+
+/// Formats datetime to a human-readable string.
+pub fn format_datetime(time: &DateTime<Utc>) -> String {
+    let duration = Utc::now().signed_duration_since(time);
     let days = duration.num_days();
     let hours = duration.num_hours() - (days * 24);
 

--- a/src/kubernetes/utils.rs
+++ b/src/kubernetes/utils.rs
@@ -53,8 +53,8 @@ pub fn format_datetime(time: &DateTime<Utc>) -> String {
 /// Kind value can be in the format `kind.group`.
 pub fn get_resource(list: Option<&Vec<(ApiResource, ApiCapabilities)>>, kind: &str) -> Option<(ApiResource, ApiCapabilities)> {
     if kind.contains('.') {
-        let mut split = kind.splitn(2, '.');
-        get_resource_with_group(list, split.next().unwrap(), split.next().unwrap())
+        let (kind, group) = kind.split_once('.').unwrap();
+        get_resource_with_group(list, kind, group)
     } else {
         get_resource_no_group(list, kind)
     }

--- a/src/ui/views/content.rs
+++ b/src/ui/views/content.rs
@@ -16,15 +16,24 @@ use crate::{
 
 use super::header::HeaderPane;
 
-pub type StyledLines = Vec<Vec<(Style, String)>>;
+pub type StyledLine = Vec<(Style, String)>;
+
+/// Content for the [`ContentViewer`].
+pub trait Content {
+    /// Returns page with [`StyledLine`]s.
+    fn page(&mut self, start: usize, count: usize) -> &[StyledLine];
+
+    /// Returns the current length of a [`Column`].
+    fn len(&self) -> usize;
+}
 
 /// Content viewer with header.
-pub struct ContentViewer {
+pub struct ContentViewer<T: Content> {
     pub header: HeaderPane,
     app_data: SharedAppData,
 
-    lines: Option<StyledLines>,
-    lines_width: usize,
+    content: Option<T>,
+    max_width: usize,
 
     page_height: usize,
     page_width: usize,
@@ -34,7 +43,7 @@ pub struct ContentViewer {
     creation_time: Instant,
 }
 
-impl ContentViewer {
+impl<T: Content> ContentViewer<T> {
     /// Creates a new content viewer.
     pub fn new(app_data: SharedAppData) -> Self {
         let header = HeaderPane::new(Rc::clone(&app_data));
@@ -42,8 +51,8 @@ impl ContentViewer {
         Self {
             header,
             app_data,
-            lines: None,
-            lines_width: 0,
+            content: None,
+            max_width: 0,
             page_height: 0,
             page_width: 0,
             page_vstart: 0,
@@ -68,41 +77,26 @@ impl ContentViewer {
         self
     }
 
-    /// Sets header data.
-    pub fn set_header_data(&mut self, namespace: Namespace, kind: String, name: String, descr: Option<String>) {
-        self.header.set_data(namespace, kind, name, descr);
-    }
-
-    /// Sets header title.
-    pub fn set_header_title(&mut self, title: &'static str) {
-        self.header.set_title(title);
-    }
-
-    /// Sets header icon.
-    pub fn set_header_icon(&mut self, icon: char) {
-        self.header.set_icon(icon);
-    }
-
     /// Returns `true` if viewer has content.
     pub fn has_content(&self) -> bool {
-        self.lines.is_some()
+        self.content.is_some()
     }
 
-    /// Sets styled content.
-    pub fn set_content(&mut self, styled_lines: StyledLines, max_width: usize) {
-        self.lines = Some(styled_lines);
-        self.lines_width = max_width;
+    /// Sets content for the viewer.
+    pub fn set_content(&mut self, content: T, max_width: usize) {
+        self.content = Some(content);
+        self.max_width = max_width;
     }
 
-    /// Returns styled content as mutable reference.
-    pub fn content_mut(&mut self) -> Option<&mut StyledLines> {
-        self.lines.as_mut()
+    /// Returns content as mutable reference.
+    pub fn content_mut(&mut self) -> Option<&mut T> {
+        self.content.as_mut()
     }
 
     /// Updates max width for content lines.
     pub fn update_max_width(&mut self, max_width: usize) {
-        if self.lines_width < max_width {
-            self.lines_width = max_width;
+        if self.max_width < max_width {
+            self.max_width = max_width;
         }
     }
 
@@ -111,11 +105,6 @@ impl ContentViewer {
         self.page_height = usize::from(new_height);
         self.page_width = usize::from(hew_width);
         self.update_page_starts();
-    }
-
-    /// Scrolls content to the end.
-    pub fn scroll_to_start(&mut self) {
-        self.page_vstart = 0;
     }
 
     /// Scrolls content to the end.
@@ -165,17 +154,16 @@ impl ContentViewer {
 
         self.header.draw(frame, layout[0]);
 
-        if self.lines.is_some() {
+        if self.content.is_some() {
             self.update_page(layout[1].height, layout[1].width);
 
             let start = self.page_vstart.clamp(0, self.max_vstart());
             let lines = self
-                .lines
-                .as_ref()
+                .content
+                .as_mut()
                 .unwrap()
+                .page(start, usize::from(layout[1].height))
                 .iter()
-                .skip(start)
-                .take(usize::from(layout[1].height))
                 .map(|items| Line::from(items.iter().map(|item| Span::styled(&item.1, item.0)).collect::<Vec<_>>()))
                 .collect::<Vec<_>>();
 
@@ -190,7 +178,7 @@ impl ContentViewer {
 
     /// Returns max vertical start of the page.
     fn max_vstart(&self) -> usize {
-        self.lines
+        self.content
             .as_ref()
             .map(|l| l.len().saturating_sub(self.page_height))
             .unwrap_or(0)
@@ -198,7 +186,7 @@ impl ContentViewer {
 
     /// Returns max horizontal start of the page.
     fn max_hstart(&self) -> usize {
-        self.lines_width.saturating_sub(self.page_width)
+        self.max_width.saturating_sub(self.page_width)
     }
 
     fn update_page_starts(&mut self) {

--- a/src/ui/views/content.rs
+++ b/src/ui/views/content.rs
@@ -93,10 +93,21 @@ impl<T: Content> ContentViewer<T> {
         self.content.as_mut()
     }
 
-    /// Updates max width for content lines.
-    pub fn update_max_width(&mut self, max_width: usize) {
-        if self.max_width < max_width {
-            self.max_width = max_width;
+    /// Adds value to the maximum width of content lines.
+    pub fn max_width_add(&mut self, rhs: usize) {
+        self.max_width = self.max_width.saturating_add(rhs);
+    }
+
+    /// Subtracts value from the maximum width of content lines.
+    pub fn max_width_sub(&mut self, rhs: usize) {
+        self.max_width = self.max_width.saturating_sub(rhs);
+    }
+
+    /// Updates max width for content lines.  
+    /// **Note** that it will not update the width if new one is smaller.
+    pub fn update_max_width(&mut self, new_max_width: usize) {
+        if self.max_width < new_max_width {
+            self.max_width = new_max_width;
         }
     }
 
@@ -115,6 +126,11 @@ impl<T: Content> ContentViewer<T> {
     /// Returns `true` if view is showing the last part of the content.
     pub fn is_at_end(&self) -> bool {
         self.page_vstart == self.max_vstart()
+    }
+
+    /// Resets horizontal scroll to start position.
+    pub fn reset_horizontal_scroll(&mut self) {
+        self.page_hstart = 0;
     }
 
     /// Process UI key event.

--- a/src/ui/views/logs/view.rs
+++ b/src/ui/views/logs/view.rs
@@ -147,6 +147,8 @@ impl View for LogsView {
                 self.toggle_timestamps();
                 return ResponseEvent::Handled;
             }
+
+            return response;
         }
 
         if self.process_command_palette_events(key) {

--- a/src/ui/views/resources/table.rs
+++ b/src/ui/views/resources/table.rs
@@ -101,7 +101,7 @@ impl ResourcesTable {
             ViewType::Compact
         });
 
-        if !self.app_data.borrow().current.is_namespace_equal(&namespace) {
+        if namespace.is_all() || !self.app_data.borrow().current.is_namespace_equal(&namespace) {
             self.app_data.borrow_mut().current.set_namespace(namespace);
             self.list.items.deselect_all();
         }
@@ -149,29 +149,27 @@ impl ResourcesTable {
         self.highlight_next = None;
 
         if key.code == KeyCode::Esc {
-            match self.kind_plural() {
-                NAMESPACES => (),
+            return match self.kind_plural() {
+                NAMESPACES => ResponseEvent::Handled,
                 CONTAINERS => {
                     let to_select = self.app_data.borrow().current.name.clone();
-                    return ResponseEvent::ChangeKindAndSelect(PODS.to_owned(), to_select);
+                    ResponseEvent::ChangeKindAndSelect(PODS.to_owned(), to_select)
                 },
-                _ => return ResponseEvent::ViewNamespaces,
-            }
+                _ => ResponseEvent::ViewNamespaces,
+            };
         }
 
         if let Some(selected_resource) = self.list.items.get_highlighted_resource() {
             if key.code == KeyCode::Enter {
-                match self.kind_plural() {
-                    NAMESPACES => return ResponseEvent::Change(PODS.to_owned(), selected_resource.name.clone()),
-                    PODS => {
-                        return ResponseEvent::ViewContainers(
-                            selected_resource.name.clone(),
-                            selected_resource.namespace.clone().unwrap_or_default(),
-                        );
-                    },
-                    CONTAINERS => return self.process_view_logs(selected_resource, false),
-                    _ => return self.process_view_yaml(selected_resource, false),
-                }
+                return match self.kind_plural() {
+                    NAMESPACES => ResponseEvent::Change(PODS.to_owned(), selected_resource.name.clone()),
+                    PODS => ResponseEvent::ViewContainers(
+                        selected_resource.name.clone(),
+                        selected_resource.namespace.clone().unwrap_or_default(),
+                    ),
+                    CONTAINERS => self.process_view_logs(selected_resource, false),
+                    _ => self.process_view_yaml(selected_resource, false),
+                };
             }
 
             if self.kind_plural() == CONTAINERS {

--- a/src/ui/views/resources/table.rs
+++ b/src/ui/views/resources/table.rs
@@ -93,6 +93,15 @@ impl ResourcesTable {
         &self.list.items.data.group
     }
 
+    /// Returns resources kind and group separated with `.` (dot).
+    pub fn get_kind_with_group(&self) -> String {
+        if self.list.items.data.group.is_empty() {
+            self.list.items.data.kind_plural.to_owned()
+        } else {
+            format!("{}.{}", self.list.items.data.kind_plural, self.list.items.data.group)
+        }
+    }
+
     /// Sets namespace for [`ResourcesTable`].
     pub fn set_namespace(&mut self, namespace: Namespace) {
         self.set_view(if namespace.is_all() {

--- a/src/ui/views/resources/view.rs
+++ b/src/ui/views/resources/view.rs
@@ -170,18 +170,27 @@ impl ResourcesView {
         if key.code == KeyCode::Left && self.table.scope() == &Scope::Namespaced && !self.table.has_containers() {
             self.ns_selector
                 .show_selected(self.app_data.borrow().current.namespace.as_str(), "");
+            return ResponseEvent::Handled;
         }
 
         if key.code == KeyCode::Right {
             self.res_selector.show_selected(self.table.kind_plural(), self.table.group());
+            return ResponseEvent::Handled;
         }
 
         if key.code == KeyCode::Char('d') && key.modifiers == KeyModifiers::CONTROL {
             self.ask_delete_resources();
+            return ResponseEvent::Handled;
+        }
+
+        if key.code == KeyCode::Esc && !self.filter.value().is_empty() {
+            self.filter.reset();
+            return ResponseEvent::Handled;
         }
 
         if key.code == KeyCode::Char('/') {
             self.filter.show();
+            return ResponseEvent::Handled;
         }
 
         self.process_command_palette_events(key);
@@ -245,13 +254,13 @@ impl ResourcesView {
                     builder
                         .with_action(
                             Action::new("show logs")
-                                .with_description("shows containter logs")
+                                .with_description("shows container logs")
                                 .with_aliases(&["logs"])
                                 .with_response(ResponseEvent::Action("show_logs")),
                         )
                         .with_action(
                             Action::new("show previous logs")
-                                .with_description("shows containter previous logs")
+                                .with_description("shows container previous logs")
                                 .with_aliases(&["previous"])
                                 .with_response(ResponseEvent::Action("show_plogs")),
                         )

--- a/src/ui/views/resources/view.rs
+++ b/src/ui/views/resources/view.rs
@@ -77,6 +77,7 @@ impl ResourcesView {
             pub fn kind_plural(&self) -> &str;
             pub fn scope(&self) -> &Scope;
             pub fn group(&self) -> &str;
+            pub fn get_kind_with_group(&self) -> String;
             pub fn get_selected_items(&self) -> HashMap<&str, Vec<&str>>;
             pub fn get_resource(&self, name: &str, namespace: &Namespace) -> Option<&Resource>;
             pub fn set_namespace(&mut self, namespace: Namespace);

--- a/src/ui/views/resources/view.rs
+++ b/src/ui/views/resources/view.rs
@@ -232,46 +232,46 @@ impl ResourcesView {
 
     fn process_command_palette_events(&mut self, key: KeyEvent) {
         if key.code == KeyCode::Char(':') || key.code == KeyCode::Char('>') {
-            let actions = if self.app_data.borrow().is_connected {
-                let builder = ActionsListBuilder::from_kinds(&self.res_selector.select.items.list)
-                    .with_resources_actions(false)
-                    .with_action(
-                        Action::new("show YAML")
-                            .with_description("shows YAML of the selected resource")
-                            .with_aliases(&["yaml"])
-                            .with_response(ResponseEvent::Action("show_yaml")),
-                    );
-                if self.table.kind_plural() == "secrets" {
-                    builder
-                        .with_action(
-                            Action::new("decode")
-                                .with_description("shows decoded YAML of the selected secret")
-                                .with_aliases(&["decode", "x"])
-                                .with_response(ResponseEvent::Action("decode_yaml")),
-                        )
-                        .build()
-                } else if self.table.kind_plural() == CONTAINERS {
-                    builder
-                        .with_action(
-                            Action::new("show logs")
-                                .with_description("shows container logs")
-                                .with_aliases(&["logs"])
-                                .with_response(ResponseEvent::Action("show_logs")),
-                        )
-                        .with_action(
-                            Action::new("show previous logs")
-                                .with_description("shows container previous logs")
-                                .with_aliases(&["previous"])
-                                .with_response(ResponseEvent::Action("show_plogs")),
-                        )
-                        .build()
-                } else {
-                    builder.build()
-                }
+            let is_containers = self.table.kind_plural() == CONTAINERS;
+            let mut builder = if self.app_data.borrow().is_connected {
+                ActionsListBuilder::from_kinds(&self.res_selector.select.items.list).with_resources_actions(!is_containers)
             } else {
-                ActionsListBuilder::default().with_resources_actions(true).build()
+                ActionsListBuilder::default().with_resources_actions(false)
             };
-            self.command_palette = CommandPalette::new(Rc::clone(&self.app_data), actions, 60);
+
+            if is_containers {
+                builder = builder
+                    .with_action(
+                        Action::new("show logs")
+                            .with_description("shows container logs")
+                            .with_aliases(&["logs"])
+                            .with_response(ResponseEvent::Action("show_logs")),
+                    )
+                    .with_action(
+                        Action::new("show previous logs")
+                            .with_description("shows container previous logs")
+                            .with_aliases(&["previous"])
+                            .with_response(ResponseEvent::Action("show_plogs")),
+                    );
+            } else {
+                builder = builder.with_action(
+                    Action::new("show YAML")
+                        .with_description("shows YAML of the selected resource")
+                        .with_aliases(&["yaml"])
+                        .with_response(ResponseEvent::Action("show_yaml")),
+                );
+            }
+
+            if self.table.kind_plural() == "secrets" {
+                builder = builder.with_action(
+                    Action::new("decode")
+                        .with_description("shows decoded YAML of the selected secret")
+                        .with_aliases(&["decode", "x"])
+                        .with_response(ResponseEvent::Action("decode_yaml")),
+                );
+            }
+
+            self.command_palette = CommandPalette::new(Rc::clone(&self.app_data), builder.build(), 60);
             self.command_palette.show();
         }
     }

--- a/src/ui/widgets/commands/actions_list.rs
+++ b/src/ui/widgets/commands/actions_list.rs
@@ -107,9 +107,9 @@ impl ActionsListBuilder {
     }
 
     /// Adds actions relevant to resources view.
-    pub fn with_resources_actions(self, is_disconnected: bool) -> Self {
+    pub fn with_resources_actions(self, is_deletable: bool) -> Self {
         let builder = self.with_context().with_quit();
-        if !is_disconnected { builder.with_delete() } else { builder }
+        if is_deletable { builder.with_delete() } else { builder }
     }
 
     /// Adds `quit` action.


### PR DESCRIPTION
This PR introduces a couple of new features:
The ability to toggle timestamps in logs using the `t` key, and expanded views for several Kubernetes resource types, including DaemonSets, Deployments, Events, Jobs, ReplicaSets, and StatefulSets.
It also addresses a bug where the resource group was not properly respected in the YAML view or during resource deletion.