### PR TITLE
Change windows-2019 to windows-2022 in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
         build: [win-msvc]
         include:
         - build: win-msvc
-          os: windows-2019
+          os: windows-2022
           rust: stable
           target: x86_64-pc-windows-msvc
     runs-on: ${{ matrix.os }}
@@ -72,7 +72,7 @@ jobs:
         staging="${{ env.BIN_NAME }}-${{ needs.create-release.outputs.tag }}-${{ matrix.target }}"
         mkdir -p "$staging"
         cp {README.md,LICENSE,CHANGELOG.md} "$staging/"
-        if [ "${{ matrix.os }}" = "windows-2019" ]; then
+        if [ "${{ matrix.os }}" = "windows-2022" ]; then
           cp "target/${{ matrix.target }}/release/${{ env.BIN_NAME }}.exe" "$staging/"
           ls -l "$staging"
           cd "$staging"


### PR DESCRIPTION
Fix for retired windows-2019 actions runner.