### PR TITLE
Fix bug with navigating to the search highlights

### DIFF
--- a/assets/themes/light.yaml
+++ b/assets/themes/light.yaml
@@ -79,7 +79,7 @@ colors:
       selected: light_green:no_bg
       selected_hl: text:light_green
     completed:
-      normal: text_light:no_bg
+      normal: text:no_bg
       normal_hl: text_light:bg_dark
       selected: light_green:no_bg
       selected_hl: text:light_green

--- a/src/ui/views/logs/view.rs
+++ b/src/ui/views/logs/view.rs
@@ -164,11 +164,19 @@ impl LogsView {
     }
 
     fn navigate_match(&mut self, forward: bool) {
-        self.logs.navigate_match(forward);
+        self.logs.navigate_match(forward, self.get_offset());
         self.footer
             .set_text("logs_search", self.logs.get_footer_text(), IconKind::Default);
         if let Some(message) = self.logs.get_footer_message(forward) {
             self.footer.show_info(message, 0);
+        }
+    }
+
+    fn get_offset(&self) -> Option<Size> {
+        if self.logs.content().is_some_and(|c| c.show_timestamps) {
+            Some(Size::new(TIMESTAMP_TEXT_LENGTH as u16, 0))
+        } else {
+            None
         }
     }
 }
@@ -240,7 +248,7 @@ impl View for LogsView {
         if self.search.is_visible {
             let result = self.search.process_key(key);
             if self.logs.search(self.search.value(), false) {
-                self.logs.scroll_to_current_match();
+                self.logs.scroll_to_current_match(self.get_offset());
                 self.update_search_count();
             }
 
@@ -294,13 +302,7 @@ impl View for LogsView {
     }
 
     fn draw(&mut self, frame: &mut Frame<'_>, area: Rect) {
-        let offset = if self.logs.content().is_some_and(|c| c.show_timestamps) {
-            Some(Size::new(TIMESTAMP_TEXT_LENGTH as u16, 0))
-        } else {
-            None
-        };
-
-        self.logs.draw(frame, area, offset);
+        self.logs.draw(frame, area, self.get_offset());
         self.command_palette.draw(frame, frame.area());
         self.search.draw(frame, frame.area());
     }

--- a/src/ui/views/resources/table.rs
+++ b/src/ui/views/resources/table.rs
@@ -173,6 +173,15 @@ impl ResourcesTable {
             return ResponseEvent::ShowPortForwards;
         }
 
+        let response = self.list.process_key(key);
+        if response != ResponseEvent::NotHandled {
+            response
+        } else {
+            self.process_highlighted_resource_key(key)
+        }
+    }
+
+    fn process_highlighted_resource_key(&mut self, key: KeyEvent) -> ResponseEvent {
         if let Some(resource) = self.list.table.get_highlighted_resource() {
             if key.code == KeyCode::Enter {
                 return self.process_enter_key(resource);
@@ -207,7 +216,7 @@ impl ResourcesTable {
             }
         }
 
-        self.list.process_key(key)
+        ResponseEvent::NotHandled
     }
 
     /// Draws [`ResourcesTable`] on the provided frame and area.

--- a/src/ui/views/resources/view.rs
+++ b/src/ui/views/resources/view.rs
@@ -8,7 +8,7 @@ use crate::{
     core::{SharedAppData, SharedBgWorker},
     kubernetes::{
         Kind, Namespace, ResourceRef,
-        resources::{CONTAINERS, Port, ResourceItem, SECRETS},
+        resources::{CONTAINERS, PODS, Port, ResourceItem, SECRETS},
         watchers::ObserverResult,
     },
     ui::{
@@ -218,8 +218,10 @@ impl ResourcesView {
         }
 
         let is_containers = self.table.kind_plural() == CONTAINERS;
+        let is_pods = self.table.kind_plural() == PODS;
         let mut builder = ActionsListBuilder::from_kinds(self.app_data.borrow().kinds.as_deref())
             .with_resources_actions(!is_containers)
+            .with_forwards()
             .with_action(
                 ActionItem::new("show YAML")
                     .with_description(if is_containers {
@@ -231,7 +233,7 @@ impl ResourcesView {
                     .with_response(ResponseEvent::Action("show_yaml")),
             );
 
-        if is_containers {
+        if is_containers || is_pods {
             builder = builder
                 .with_action(
                     ActionItem::new("show logs")

--- a/src/ui/views/yaml/view.rs
+++ b/src/ui/views/yaml/view.rs
@@ -119,7 +119,7 @@ impl YamlView {
     }
 
     fn navigate_match(&mut self, forward: bool) {
-        self.yaml.navigate_match(forward);
+        self.yaml.navigate_match(forward, None);
         self.footer
             .set_text("yaml_search", self.yaml.get_footer_text(), IconKind::Default);
         if let Some(message) = self.yaml.get_footer_message(forward) {
@@ -181,7 +181,7 @@ impl View for YamlView {
         if self.search.is_visible {
             let result = self.search.process_key(key);
             if self.yaml.search(self.search.value(), false) {
-                self.yaml.scroll_to_current_match();
+                self.yaml.scroll_to_current_match(None);
                 self.update_search_count();
             }
 

--- a/src/ui/widgets/commands/actions_list.rs
+++ b/src/ui/widgets/commands/actions_list.rs
@@ -146,7 +146,7 @@ impl ActionsListBuilder {
 
     /// Adds actions relevant to resources view.
     pub fn with_resources_actions(self, is_deletable: bool) -> Self {
-        let builder = self.with_context().with_forwards().with_theme().with_quit();
+        let builder = self.with_context().with_theme().with_quit();
         if is_deletable { builder.with_delete() } else { builder }
     }
 


### PR DESCRIPTION
This PR fixes several bugs:
- `show port forwards` is displayed in the command palette even when disconnected from k8s
- `ALT + s` does not sort the column in the pods view
- in the logs view, when highlighting the next search match, the view does not scroll to the match position (offset is not respected)