### PR TITLE
Allow insecure connections

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,29 +2,33 @@ use clap::Parser;
 
 use crate::kubernetes::ALL_NAMESPACES;
 
-/// Simple program to list resources in kubernetes.
+/// Simple program to view resources in a Kubernetes cluster.
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
 pub struct Args {
-    /// Path to the kube config file.
+    /// Path to the kubeconfig file.
     #[arg(long)]
     pub kube_config: Option<String>,
 
-    /// Context to use, defined in kube config
+    /// Context to use, as defined in the kubeconfig.
     #[arg(long)]
     pub context: Option<String>,
 
-    /// Kubernetes resource to list
+    /// Kubernetes resource to view (e.g., pods, services).
     #[arg()]
     pub resource: Option<String>,
 
-    /// Kubernetes namespace for the resource to list
+    /// Namespace of the resource to view.
     #[arg(long, short)]
     pub namespace: Option<String>,
 
-    /// List resource in all namespaces
+    /// View resources in all namespaces.
     #[arg(long)]
     pub all_namespaces: bool,
+
+    /// Allow insecure connections (skip TLS verification).
+    #[arg(long)]
+    pub insecure: bool,
 }
 
 impl Args {

--- a/src/core/app.rs
+++ b/src/core/app.rs
@@ -38,13 +38,14 @@ pub struct App {
 
 impl App {
     /// Creates new [`App`] instance.
-    pub fn new(config: Config, history: History, theme: Theme) -> Result<Self> {
+    pub fn new(config: Config, history: History, theme: Theme, allow_insecure: bool) -> Result<Self> {
         let theme_path = config.theme_path();
         let data = Rc::new(RefCell::new(AppData::new(config, history, theme)));
         let footer = Footer::new(Rc::clone(&data));
         let worker = Rc::new(RefCell::new(BgWorker::new(footer.get_transmitter())));
         let resources = ResourcesView::new(Rc::clone(&data), Rc::clone(&worker));
-        let client_manager = KubernetesClientManager::new(Rc::clone(&data), Rc::clone(&worker), footer.get_transmitter());
+        let client_manager =
+            KubernetesClientManager::new(Rc::clone(&data), Rc::clone(&worker), footer.get_transmitter(), allow_insecure);
         let views_manager = ViewsManager::new(Rc::clone(&data), Rc::clone(&worker), resources, footer);
 
         Ok(Self {

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,7 +55,7 @@ async fn run_application(args: cli::Args) -> Result<()> {
 
     let config = Config::load_or_create().await?;
     let theme = config.load_or_create_theme().await?;
-    let mut app = App::new(config, history, theme)?;
+    let mut app = App::new(config, history, theme, args.insecure)?;
     app.start(context, kind, namespace)?;
 
     loop {


### PR DESCRIPTION
Adds `--insecure` switch to the `b4n` parameters. If provided the TLS certificate of k8s API server will not be verified.