### PR TITLE
Filter pinning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - add prefixes for resources view filtering (ns: namespace, n: name, a: annotations, l: labels)
+- pin active filter across resources with `Ctrl+P`
 - validate and remember manually entered namespaces
 
 ### Bug fixes

--- a/b4n-common/expr/selective_map.rs
+++ b/b4n-common/expr/selective_map.rs
@@ -7,6 +7,7 @@ use crate::expr::EvaluationSource;
 pub struct SelectiveMap {
     map: HashMap<&'static str, Vec<String>>,
     explicit_only: HashSet<&'static str>,
+    optional: HashSet<&'static str>,
 }
 
 impl SelectiveMap {
@@ -17,9 +18,16 @@ impl SelectiveMap {
     }
 
     /// Inserts a key-value list and marks it as explicit-only.\
-    /// This key will **not** be searched during unprefixed matching.
+    /// **Note** that this key will not be searched during unprefixed matching.
     pub fn with_explicit(mut self, key: &'static str, values: Vec<String>) -> Self {
         self.insert_explicit(key, values);
+        self
+    }
+
+    /// Inserts a key-value list and marks it as optional.\
+    /// **Note** that if this key is absent from the map, `contains_in_key` returns `true`.
+    pub fn with_optional(mut self, key: &'static str, values: Vec<String>) -> Self {
+        self.insert_optional(key, values);
         self
     }
 
@@ -35,6 +43,25 @@ impl SelectiveMap {
     pub fn insert_explicit(&mut self, key: &'static str, values: Vec<String>) -> &mut Self {
         self.map.insert(key, values);
         self.explicit_only.insert(key);
+        self
+    }
+
+    /// Inserts a key-value list and marks it as optional.
+    pub fn insert_optional(&mut self, key: &'static str, values: Vec<String>) -> &mut Self {
+        self.map.insert(key, values);
+        self.optional.insert(key);
+        self
+    }
+
+    /// Marks an existing key as optional.
+    pub fn set_optional(&mut self, key: &'static str) -> &mut Self {
+        self.optional.insert(key);
+        self
+    }
+
+    /// Removes the optional mark from a key.
+    pub fn set_required(&mut self, key: &'static str) -> &mut Self {
+        self.optional.remove(key);
         self
     }
 
@@ -54,14 +81,19 @@ impl SelectiveMap {
     pub fn is_explicit(&self, key: &str) -> bool {
         self.explicit_only.contains(key)
     }
+
+    /// Returns `true` if the key is marked as optional.
+    pub fn is_optional(&self, key: &str) -> bool {
+        self.optional.contains(key)
+    }
 }
 
 impl EvaluationSource for SelectiveMap {
     fn contains_in_key(&self, key: &str, value: &str) -> bool {
-        self.map
-            .get(key)
-            .map(|items| items.iter().any(|s| s.contains(value)))
-            .unwrap_or(false)
+        match self.map.get(key) {
+            Some(items) => items.iter().any(|s| s.contains(value)),
+            None => self.optional.contains(key), // true if optional, false otherwise
+        }
     }
 
     fn contains_in_any(&self, value: &str) -> bool {

--- a/b4n-config/keys/binding.rs
+++ b/b4n-config/keys/binding.rs
@@ -32,6 +32,7 @@ define_key_commands! {
         ContentCopy => "content.copy" @ "C",
         EventsShow => "events.show" @ "E",
         FilterOpen => "filter.open" @ "/", "Shift+/",
+        FilterPin => "filter.pin" @ "Ctrl+P",
         FilterReset => "filter.reset" @ "Esc",
         HistoryOpen => "history.open" @ "H",
         InvolvedObjectShow => "involved-object.show" @ "I",

--- a/b4n/core/data.rs
+++ b/b4n/core/data.rs
@@ -148,6 +148,10 @@ pub struct AppData {
     pub current: ResourcesInfo,
     pub previous: Vec<PreviousData>,
 
+    /// Filter that should be applied to all resources.
+    pub pinned_filter: Option<String>,
+    pub is_pinned: bool,
+
     /// Holds all discovered kinds.
     pub kinds: Option<Vec<KindItem>>,
 
@@ -165,15 +169,11 @@ impl AppData {
         Self {
             config,
             key_bindings,
-            disabled_commands: HashSet::default(),
-            disabled_keys: HashSet::default(),
             history,
             theme,
-            current: ResourcesInfo::default(),
-            previous: Vec::new(),
-            kinds: None,
             clipboard: Clipboard::new().ok(),
             state: ConnectionState::Connecting,
+            ..Default::default()
         }
     }
 

--- a/b4n/kube/resources/resource.rs
+++ b/b4n/kube/resources/resource.rs
@@ -37,14 +37,16 @@ pub struct ResourceItem {
     pub is_cached: bool,
     creation_timestamp: Option<Timestamp>,
     filter_metadata: SelectiveMap,
+    ignore_filters: bool,
 }
 
 impl ResourceItem {
     /// Creates light [`ResourceItem`] version just with name.
-    pub fn new(name: &str) -> Self {
+    pub fn new(name: &str, ignore_filters: bool) -> Self {
         Self {
             uid: format!("_{name}_"),
             name: name.to_owned(),
+            ignore_filters,
             ..Default::default()
         }
     }
@@ -59,7 +61,7 @@ impl ResourceItem {
         is_filtered: bool,
     ) -> Self {
         let data = Some(get_resource_data(kind, group, crd, stats, &object, is_filtered));
-        let filter = get_filter_metadata(&object);
+        let filter = get_filter_metadata(kind, group, &object.metadata);
         let uid = get_object_uid(&object);
         let creation_timestamp = get_age_time(&object.metadata);
         let involved_object = get_involved_object(kind, &object);
@@ -97,7 +99,8 @@ impl ResourceItem {
             container_name,
             if is_init_container { "I" } else { "M" }
         );
-        let filter = SelectiveMap::default().with("", vec![container_name.to_ascii_lowercase()]);
+        let mut filter = get_filter_metadata("Container", "", pod_metadata);
+        filter.insert("n", vec![container_name.to_ascii_lowercase()]);
 
         Self {
             age: get_age_string(pod_metadata),
@@ -293,29 +296,39 @@ impl Filterable<ResourceFilterContext> for ResourceItem {
     /// **Note** that currently it has only a switch for normal/extended filtering.
     fn is_matching(&self, context: &mut ResourceFilterContext) -> bool {
         if let Some(expression) = &context.extended {
-            self.filter_metadata.evaluate(expression)
+            self.ignore_filters || self.filter_metadata.evaluate(expression)
         } else {
             self.name.contains(&context.pattern)
         }
     }
 }
 
-fn get_filter_metadata(object: &DynamicObject) -> SelectiveMap {
-    let mut result = SelectiveMap::default();
-    result.insert("n", vec![object.name_any()]);
+fn get_filter_metadata(kind: &str, group: &str, metadata: &ObjectMeta) -> SelectiveMap {
+    let name = metadata
+        .name
+        .clone()
+        .or_else(|| metadata.generate_name.clone())
+        .unwrap_or_default();
 
-    if let Some(namespace) = object.namespace() {
+    let mut result = SelectiveMap::default();
+
+    if let Some(namespace) = metadata.namespace.clone() {
         result.insert_explicit("ns", vec![namespace]);
+    } else if kind == "Namespace" && group.is_empty() {
+        result.insert_explicit("ns", vec![name.clone()]);
+    } else {
+        result.set_optional("ns");
     }
 
-    if let Some(labels) = object.metadata.labels.as_ref() {
+    if let Some(labels) = metadata.labels.as_ref() {
         result.insert("l", flatten_metadata(labels));
     }
 
-    if let Some(annotations) = object.metadata.annotations.as_ref() {
+    if let Some(annotations) = metadata.annotations.as_ref() {
         result.insert("a", flatten_metadata(annotations));
     }
 
+    result.insert("n", vec![name]);
     result
 }
 

--- a/b4n/kube/resources/resource.tests.rs
+++ b/b4n/kube/resources/resource.tests.rs
@@ -15,7 +15,7 @@ use super::*;
 #[case("really long nam", "really long name", 15)]
 fn get_text_name_test(#[case] expected: &str, #[case] resource: &str, #[case] terminal_width: usize) {
     let header = Header::default();
-    let item = Item::new(ResourceItem::new(resource));
+    let item = Item::new(ResourceItem::new(resource, false));
 
     let (namespace_width, name_width, name_extra_width) = header.get_widths(ViewType::Compact, terminal_width);
 
@@ -40,7 +40,7 @@ fn get_text_name_test(#[case] expected: &str, #[case] resource: &str, #[case] te
 #[case("test         n/a", "test", 16)]
 fn get_text_compact_test(#[case] expected: &str, #[case] resource: &str, #[case] terminal_width: usize) {
     let header = Header::default();
-    let item = Item::new(ResourceItem::new(resource));
+    let item = Item::new(ResourceItem::new(resource, false));
 
     let (namespace_width, name_width, name_extra_width) = header.get_widths(ViewType::Compact, terminal_width);
 
@@ -68,7 +68,7 @@ fn get_text_compact_test(#[case] expected: &str, #[case] resource: &str, #[case]
 #[case("n/a         test             n/a", "test", 32)]
 fn get_text_full_test(#[case] expected: &str, #[case] resource: &str, #[case] terminal_width: usize) {
     let header = Header::default();
-    let item = Item::new(ResourceItem::new(resource));
+    let item = Item::new(ResourceItem::new(resource, false));
 
     let (namespace_width, name_width, name_extra_width) = header.get_widths(ViewType::Full, terminal_width);
 
@@ -105,7 +105,7 @@ fn get_text_pod_test() {
 
     let (namespace_width, name_width, name_extra_width) = header.get_widths(ViewType::Full, terminal_width);
 
-    let mut item = Item::new(ResourceItem::new("local-path-provisioner-84db5d44d9-kjjp5"));
+    let mut item = Item::new(ResourceItem::new("local-path-provisioner-84db5d44d9-kjjp5", false));
     item.data.namespace = Some("kube-system".to_owned());
     item.data.data = Some(ResourceData {
         extra_values: vec![
@@ -162,7 +162,7 @@ fn align_column_to_right_test() {
 
     let (namespace_width, name_width, name_extra_width) = header.get_widths(ViewType::Full, terminal_width);
 
-    let mut item = Item::new(ResourceItem::new("local-path-provisioner-84db5d44d9-kjjp5"));
+    let mut item = Item::new(ResourceItem::new("local-path-provisioner-84db5d44d9-kjjp5", false));
     item.data.namespace = Some("kube-system".to_owned());
     item.data.data = Some(ResourceData {
         extra_values: vec![Some("555555".to_owned()).into(), Some("10.42.1.201".to_owned()).into()].into_boxed_slice(),

--- a/b4n/kube/resources/resources_list.rs
+++ b/b4n/kube/resources/resources_list.rs
@@ -217,7 +217,7 @@ impl ResourcesList {
 
     fn add_all_namespaces_item(&mut self) {
         if self.table.list.full_len() == 0 && self.data.kind_plural == NAMESPACES {
-            self.table.list.push(Item::fixed(ResourceItem::new(ALL_NAMESPACES)));
+            self.table.list.push(Item::fixed(ResourceItem::new(ALL_NAMESPACES, true)));
         }
     }
 }

--- a/b4n/ui/presentation/utils.rs
+++ b/b4n/ui/presentation/utils.rs
@@ -68,7 +68,7 @@ pub fn get_left_breadcrumbs<'a>(
     }
 
     let count_icon = if is_filtered {
-        ""
+        if app_data.is_pinned { "󰐃" } else { "" }
     } else if data.resource.is_container() {
         ""
     } else {

--- a/b4n/ui/views/resources/table.rs
+++ b/b4n/ui/views/resources/table.rs
@@ -287,10 +287,12 @@ impl ResourcesTable {
     }
 
     fn process_init_result(&mut self, is_final: bool) {
-        if self.app_data.borrow().is_pinned
-            && let Some(filter) = self.app_data.borrow().pinned_filter.as_deref()
-        {
-            Self::set_filter_internal(&mut self.header, &mut self.list, filter);
+        if self.app_data.borrow().is_pinned {
+            if let Some(filter) = self.app_data.borrow().pinned_filter.as_deref() {
+                Self::set_filter_internal(&mut self.header, &mut self.list, filter);
+            } else {
+                Self::set_filter_internal(&mut self.header, &mut self.list, "");
+            }
         } else if let Some(filter) = self.next_refresh.apply_filter.as_deref() {
             Self::set_filter_internal(&mut self.header, &mut self.list, filter);
         } else {

--- a/b4n/ui/views/resources/table.rs
+++ b/b4n/ui/views/resources/table.rs
@@ -151,6 +151,7 @@ impl ResourcesTable {
             pub fn get_resource(&self, name: &str, namespace: &Namespace) -> Option<&ResourceItem>;
             pub fn has_containers(&self) -> bool;
             pub fn is_filtered(&self) -> bool;
+            pub fn filter(&self) -> Option<&str>;
         }
     }
 
@@ -218,16 +219,7 @@ impl ResourcesTable {
 
     /// Sets filter on the resources list.
     pub fn set_filter(&mut self, value: &str) {
-        self.header.show_filtered_icon(!value.is_empty());
-        if value.is_empty() {
-            if self.list.table.is_filtered() {
-                self.list.table.set_filter(None);
-                self.header.set_count(self.list.table.len());
-            }
-        } else if self.list.table.filter().is_none_or(|f| f != value) {
-            self.list.table.set_filter(Some(value.to_owned()));
-            self.header.set_count(self.list.table.len());
-        }
+        Self::set_filter_internal(&mut self.header, &mut self.list, value);
     }
 
     /// Updates resources list with a new data from [`ObserverResult`].
@@ -281,11 +273,28 @@ impl ResourcesTable {
         self.list.draw(frame, layout[1]);
     }
 
+    fn set_filter_internal(header: &mut ListHeader, list: &mut ListViewer<ResourcesList>, value: &str) {
+        header.show_filtered_icon(!value.is_empty());
+        if value.is_empty() {
+            if list.table.is_filtered() {
+                list.table.set_filter(None);
+                header.set_count(list.table.len());
+            }
+        } else if list.table.filter().is_none_or(|f| f != value) {
+            list.table.set_filter(Some(value.to_owned()));
+            header.set_count(list.table.len());
+        }
+    }
+
     fn process_init_result(&mut self, is_final: bool) {
-        if let Some(filter) = self.next_refresh.apply_filter.clone() {
-            self.set_filter(&filter);
+        if self.app_data.borrow().is_pinned
+            && let Some(filter) = self.app_data.borrow().pinned_filter.as_deref()
+        {
+            Self::set_filter_internal(&mut self.header, &mut self.list, filter);
+        } else if let Some(filter) = self.next_refresh.apply_filter.as_deref() {
+            Self::set_filter_internal(&mut self.header, &mut self.list, filter);
         } else {
-            self.set_filter("");
+            Self::set_filter_internal(&mut self.header, &mut self.list, "");
         }
 
         if is_final {

--- a/b4n/ui/views/resources/view.rs
+++ b/b4n/ui/views/resources/view.rs
@@ -102,8 +102,12 @@ impl ResourcesView {
         let is_init = matches!(result, ObserverResult::Init(_));
 
         if is_init {
-            // apply_filter must be checked before updating the table list, it is cleared there
-            if let Some(filter) = self.table.next_refresh().apply_filter.as_deref() {
+            if self.app_data.borrow().is_pinned
+                && let Some(filter) = &self.app_data.borrow().pinned_filter
+            {
+                self.filter.set_value(filter.to_owned());
+            } else if let Some(filter) = self.table.next_refresh().apply_filter.as_deref() {
+                // apply_filter must be checked before updating the table list, it is cleared there
                 self.filter.set_value(filter.to_owned());
             } else {
                 self.filter.reset();
@@ -659,6 +663,10 @@ impl View for ResourcesView {
         if self.filter.is_visible {
             let result = self.filter.process_event(event);
             self.table.set_filter(self.filter.value());
+            if self.app_data.borrow().is_pinned {
+                self.app_data.borrow_mut().pinned_filter = self.table.filter().map(String::from);
+            }
+
             return result;
         }
 
@@ -677,7 +685,19 @@ impl View for ResourcesView {
             return ResponseEvent::Handled;
         }
 
-        if self.app_data.has_binding(event, KeyCommand::FilterReset) && !self.filter.value().is_empty() {
+        if self.app_data.has_binding(event, KeyCommand::FilterPin) && !self.filter.value().is_empty() {
+            if self.app_data.borrow().is_pinned {
+                self.app_data.borrow_mut().is_pinned = false;
+            } else {
+                self.app_data.borrow_mut().is_pinned = true;
+                self.app_data.borrow_mut().pinned_filter = Some(self.filter.value().to_owned());
+            }
+        }
+
+        if !self.app_data.borrow().is_pinned
+            && self.app_data.has_binding(event, KeyCommand::FilterReset)
+            && !self.filter.value().is_empty()
+        {
             self.filter.reset();
             self.table.set_filter("");
             return ResponseEvent::Handled;

--- a/b4n/ui/views/resources/view.rs
+++ b/b4n/ui/views/resources/view.rs
@@ -613,7 +613,7 @@ impl View for ResourcesView {
     }
 
     fn is_resources_selector_allowed(&self) -> bool {
-        !self.filter.is_visible && !self.modal.is_visible && !self.command_palette.is_visible
+        !self.filter.is_visible && !self.modal.is_visible && !self.command_palette.is_visible && !self.namespace_picker.is_visible
     }
 
     fn process_tick(&mut self) -> ResponseEvent {

--- a/b4n/ui/views/resources/view.rs
+++ b/b4n/ui/views/resources/view.rs
@@ -102,10 +102,12 @@ impl ResourcesView {
         let is_init = matches!(result, ObserverResult::Init(_));
 
         if is_init {
-            if self.app_data.borrow().is_pinned
-                && let Some(filter) = &self.app_data.borrow().pinned_filter
-            {
-                self.filter.set_value(filter.to_owned());
+            if self.app_data.borrow().is_pinned {
+                if let Some(filter) = &self.app_data.borrow().pinned_filter {
+                    self.filter.set_value(filter.to_owned());
+                } else {
+                    self.filter.reset();
+                }
             } else if let Some(filter) = self.table.next_refresh().apply_filter.as_deref() {
                 // apply_filter must be checked before updating the table list, it is cleared there
                 self.filter.set_value(filter.to_owned());

--- a/b4n/ui/widgets/pickers/base.rs
+++ b/b4n/ui/widgets/pickers/base.rs
@@ -65,6 +65,11 @@ pub trait PickerBehaviour {
         false
     }
 
+    /// Gets response that should be returned by the picker on accepting selected item.
+    fn navigate_into(&self, _pattern: &str, _highlighted: Option<&str>) -> ResponseEvent {
+        ResponseEvent::Handled
+    }
+
     /// Called before drawing.
     fn on_draw(&mut self, _patterns: &mut Select<PatternsList>, _area: Rect) {}
 
@@ -76,9 +81,14 @@ pub trait PickerBehaviour {
     /// Draws the header area.
     fn draw_header(&self, _frame: &mut ratatui::Frame<'_>, _area: Rect, _style: Style) {}
 
-    /// Gets response that should be returned by the picker on accepting selected item.
-    fn get_response(&self, _pattern: &str, _highlighted: Option<&str>) -> ResponseEvent {
-        ResponseEvent::Handled
+    /// Additional events processing logic.
+    fn process_event(
+        &mut self,
+        _event: &TuiEvent,
+        _patterns: &mut Select<PatternsList>,
+        _app_data: &SharedAppData,
+    ) -> ResponseEvent {
+        ResponseEvent::NotHandled
     }
 }
 
@@ -257,7 +267,7 @@ impl<B: PickerBehaviour> Responsive for Picker<B> {
 
             return self
                 .behaviour
-                .get_response(self.patterns.value(), self.patterns.get_highlighted_item_name());
+                .navigate_into(self.patterns.value(), self.patterns.get_highlighted_item_name());
         }
 
         if event.is_mouse(MouseEventKind::RightClick) {
@@ -279,7 +289,12 @@ impl<B: PickerBehaviour> Responsive for Picker<B> {
 
             return self
                 .behaviour
-                .get_response(self.patterns.value(), self.patterns.get_highlighted_item_name());
+                .navigate_into(self.patterns.value(), self.patterns.get_highlighted_item_name());
+        }
+
+        let result = self.behaviour.process_event(event, &mut self.patterns, &self.app_data);
+        if result != ResponseEvent::NotHandled {
+            return result;
         }
 
         self.patterns.process_event(event);

--- a/b4n/ui/widgets/pickers/base.rs
+++ b/b4n/ui/widgets/pickers/base.rs
@@ -16,7 +16,7 @@ pub trait PickerBehaviour {
     fn prompt(&self) -> &str;
 
     /// Gets colors to use in the picker.
-    fn colors(&self, app_data: &SharedAppData) -> SelectColors;
+    fn colors(&self) -> SelectColors;
 
     /// Gets optional accent characters for the input.
     fn accent_characters(&self) -> Option<&str> {
@@ -30,13 +30,13 @@ pub trait PickerBehaviour {
     fn cancel_response(&self) -> ResponseEvent;
 
     /// Loads items when the picker is shown.
-    fn load_items(&self, app_data: &SharedAppData) -> PatternsList;
+    fn load_items(&self) -> PatternsList;
 
     /// Adds an item to the configuration history.
-    fn add_item(&self, app_data: &SharedAppData, item: &str);
+    fn add_item(&self, item: &str);
 
     /// Removes an item from the configuration history.
-    fn remove_item(&self, app_data: &SharedAppData, item: &str) -> bool;
+    fn remove_item(&self, item: &str) -> bool;
 
     /// Gets value indicating whether highlighted item can be removed.
     fn can_remove(&self, item: Option<&PatternItem>) -> bool {
@@ -105,8 +105,7 @@ pub struct Picker<B: PickerBehaviour> {
 impl<B: PickerBehaviour> Picker<B> {
     /// Creates new [`Picker`] instance.
     pub fn new_picker(app_data: SharedAppData, worker: Option<SharedBgWorker>, width: u16, behaviour: B) -> Self {
-        let colors = behaviour.colors(&app_data);
-        let mut select = Select::new(PatternsList::default(), colors, false, true).with_prompt(behaviour.prompt());
+        let mut select = Select::new(PatternsList::default(), behaviour.colors(), false, true).with_prompt(behaviour.prompt());
 
         if let Some(accents) = behaviour.accent_characters() {
             select = select.with_accent_characters(accents);
@@ -127,9 +126,10 @@ impl<B: PickerBehaviour> Picker<B> {
 
     /// Marks the picker as visible and loads items.
     pub fn show(&mut self) {
-        self.patterns.items = self.behaviour.load_items(&self.app_data);
+        self.patterns.items = self.behaviour.load_items();
         self.patterns.update_items_filter();
-        self.patterns.set_colors(self.behaviour.colors(&self.app_data));
+        self.patterns.set_colors(self.behaviour.colors());
+        self.patterns.set_prompt(self.behaviour.prompt());
         self.is_visible = true;
     }
 
@@ -198,7 +198,7 @@ impl<B: PickerBehaviour> Picker<B> {
     fn remember_pattern(&mut self) {
         let pattern = self.patterns.value();
         self.current = pattern.to_owned();
-        self.behaviour.add_item(&self.app_data, pattern);
+        self.behaviour.add_item(pattern);
         self.save_history_file();
     }
 
@@ -240,7 +240,7 @@ impl<B: PickerBehaviour> Responsive for Picker<B> {
         if self.app_data.has_binding(event, KeyCommand::NavigateDelete) {
             if self.behaviour.can_remove(self.patterns.items.get_highlighted())
                 && let Some(removed) = self.patterns.items.remove_highlighted()
-                && self.behaviour.remove_item(&self.app_data, &removed)
+                && self.behaviour.remove_item(&removed)
             {
                 self.save_history_file();
             }

--- a/b4n/ui/widgets/pickers/filter.rs
+++ b/b4n/ui/widgets/pickers/filter.rs
@@ -6,6 +6,7 @@ use b4n_tui::{ResponseEvent, TuiEvent};
 use ratatui::layout::Rect;
 use ratatui::style::Style;
 use ratatui::widgets::Paragraph;
+use std::rc::Rc;
 
 use crate::core::{SharedAppData, SharedAppDataExt, SharedBgWorker};
 use crate::ui::widgets::pickers::base::PickerBehaviour;
@@ -15,6 +16,7 @@ use crate::ui::widgets::{PatternsList, Picker};
 #[path = "./filter.tests.rs"]
 mod filter_tests;
 
+const FILTER_HINT: &str = " Use | for OR, & for AND, and parentheses to group terms.";
 const FILTER_HISTORY_SIZE: usize = 20;
 
 pub type Filter = Picker<FilterBehaviour>;
@@ -22,36 +24,34 @@ pub type Filter = Picker<FilterBehaviour>;
 impl Filter {
     /// Creates new [`Filter`] instance.
     pub fn new(app_data: SharedAppData, worker: Option<SharedBgWorker>, width: u16) -> Self {
-        let behaviour = FilterBehaviour::new(&app_data);
+        let behaviour = FilterBehaviour::new(Rc::clone(&app_data));
         Picker::new_picker(app_data, worker, width, behaviour)
     }
 }
 
 pub struct FilterBehaviour {
-    hint: &'static str,
+    app_data: SharedAppData,
     last_validated: String,
     last_error: Option<usize>,
-    is_pinned: bool,
 }
 
 impl FilterBehaviour {
-    pub fn new(app_data: &SharedAppData) -> Self {
+    pub fn new(app_data: SharedAppData) -> Self {
         Self {
-            hint: " Use | for OR, & for AND, and parentheses to group terms.",
+            app_data,
             last_validated: String::new(),
             last_error: None,
-            is_pinned: app_data.borrow().is_pinned,
         }
     }
 }
 
 impl PickerBehaviour for FilterBehaviour {
     fn prompt(&self) -> &str {
-        if self.is_pinned { "󰐃 " } else { " " }
+        if self.app_data.borrow().is_pinned { "󰐃 " } else { " " }
     }
 
-    fn colors(&self, app_data: &SharedAppData) -> SelectColors {
-        app_data.borrow().theme.colors.filter.clone()
+    fn colors(&self) -> SelectColors {
+        self.app_data.borrow().theme.colors.filter.clone()
     }
 
     fn accent_characters(&self) -> Option<&str> {
@@ -66,23 +66,23 @@ impl PickerBehaviour for FilterBehaviour {
         ResponseEvent::Cancelled
     }
 
-    fn load_items(&self, app_data: &SharedAppData) -> PatternsList {
-        let context = &app_data.borrow().current.context;
-        let key_name = app_data.get_key_name(KeyCommand::NavigateComplete).to_ascii_uppercase();
-        PatternsList::from(app_data.borrow().history.filter_history(context), Some(&key_name))
+    fn load_items(&self) -> PatternsList {
+        let context = &self.app_data.borrow().current.context;
+        let key_name = self.app_data.get_key_name(KeyCommand::NavigateComplete).to_ascii_uppercase();
+        PatternsList::from(self.app_data.borrow().history.filter_history(context), Some(&key_name))
     }
 
-    fn add_item(&self, app_data: &SharedAppData, item: &str) {
-        let context = app_data.borrow().current.context.clone();
-        app_data
+    fn add_item(&self, item: &str) {
+        let context = self.app_data.borrow().current.context.clone();
+        self.app_data
             .borrow_mut()
             .history
             .put_filter_history_item(&context, item.into(), FILTER_HISTORY_SIZE);
     }
 
-    fn remove_item(&self, app_data: &SharedAppData, item: &str) -> bool {
-        let context = app_data.borrow().current.context.clone();
-        app_data
+    fn remove_item(&self, item: &str) -> bool {
+        let context = self.app_data.borrow().current.context.clone();
+        self.app_data
             .borrow_mut()
             .history
             .remove_filter_history_item(&context, item)
@@ -115,7 +115,7 @@ impl PickerBehaviour for FilterBehaviour {
     }
 
     fn draw_header(&self, frame: &mut ratatui::Frame<'_>, area: Rect, style: Style) {
-        frame.render_widget(Paragraph::new(self.hint).style(style), area);
+        frame.render_widget(Paragraph::new(FILTER_HINT).style(style), area);
     }
 
     fn process_event(
@@ -125,8 +125,8 @@ impl PickerBehaviour for FilterBehaviour {
         app_data: &SharedAppData,
     ) -> ResponseEvent {
         if app_data.has_binding(event, KeyCommand::FilterPin) {
-            self.is_pinned = !app_data.borrow().is_pinned;
-            app_data.borrow_mut().is_pinned = self.is_pinned;
+            let is_pinned = !app_data.borrow().is_pinned;
+            app_data.borrow_mut().is_pinned = is_pinned;
             patterns.set_prompt(self.prompt());
 
             return ResponseEvent::Handled;

--- a/b4n/ui/widgets/pickers/filter.rs
+++ b/b4n/ui/widgets/pickers/filter.rs
@@ -1,7 +1,8 @@
 use b4n_common::expr::{ParserError, validate};
 use b4n_config::keys::KeyCommand;
 use b4n_config::themes::SelectColors;
-use b4n_tui::ResponseEvent;
+use b4n_tui::widgets::Select;
+use b4n_tui::{ResponseEvent, TuiEvent};
 use ratatui::layout::Rect;
 use ratatui::style::Style;
 use ratatui::widgets::Paragraph;
@@ -21,7 +22,8 @@ pub type Filter = Picker<FilterBehaviour>;
 impl Filter {
     /// Creates new [`Filter`] instance.
     pub fn new(app_data: SharedAppData, worker: Option<SharedBgWorker>, width: u16) -> Self {
-        Picker::new_picker(app_data, worker, width, FilterBehaviour::default())
+        let behaviour = FilterBehaviour::new(&app_data);
+        Picker::new_picker(app_data, worker, width, behaviour)
     }
 }
 
@@ -29,21 +31,23 @@ pub struct FilterBehaviour {
     hint: &'static str,
     last_validated: String,
     last_error: Option<usize>,
+    is_pinned: bool,
 }
 
-impl Default for FilterBehaviour {
-    fn default() -> Self {
+impl FilterBehaviour {
+    pub fn new(app_data: &SharedAppData) -> Self {
         Self {
             hint: " Use | for OR, & for AND, and parentheses to group terms.",
             last_validated: String::new(),
             last_error: None,
+            is_pinned: app_data.borrow().is_pinned,
         }
     }
 }
 
 impl PickerBehaviour for FilterBehaviour {
     fn prompt(&self) -> &str {
-        " "
+        if self.is_pinned { "󰐃 " } else { " " }
     }
 
     fn colors(&self, app_data: &SharedAppData) -> SelectColors {
@@ -112,5 +116,22 @@ impl PickerBehaviour for FilterBehaviour {
 
     fn draw_header(&self, frame: &mut ratatui::Frame<'_>, area: Rect, style: Style) {
         frame.render_widget(Paragraph::new(self.hint).style(style), area);
+    }
+
+    fn process_event(
+        &mut self,
+        event: &TuiEvent,
+        patterns: &mut Select<PatternsList>,
+        app_data: &SharedAppData,
+    ) -> ResponseEvent {
+        if app_data.has_binding(event, KeyCommand::FilterPin) {
+            self.is_pinned = !app_data.borrow().is_pinned;
+            app_data.borrow_mut().is_pinned = self.is_pinned;
+            patterns.set_prompt(self.prompt());
+
+            return ResponseEvent::Handled;
+        }
+
+        ResponseEvent::NotHandled
     }
 }

--- a/b4n/ui/widgets/pickers/namespace.rs
+++ b/b4n/ui/widgets/pickers/namespace.rs
@@ -2,6 +2,7 @@ use b4n_config::keys::KeyCommand;
 use b4n_config::themes::SelectColors;
 use b4n_tui::ResponseEvent;
 use b4n_tui::widgets::{ErrorHighlightMode, InputValidator, ValidatorKind};
+use std::rc::Rc;
 
 use crate::core::{SharedAppData, SharedAppDataExt, SharedBgWorker};
 use crate::ui::widgets::{PatternItem, PatternsList, Picker, PickerBehaviour};
@@ -13,7 +14,8 @@ pub type NamespaceSelector = Picker<NamespaceBehaviour>;
 impl NamespaceSelector {
     /// Creates new [`NamespaceSelector`] instance.
     pub fn new(app_data: SharedAppData, worker: Option<SharedBgWorker>, width: u16) -> Self {
-        Picker::new_picker(app_data, worker, width, NamespaceBehaviour::default())
+        let behaviour = NamespaceBehaviour::new(Rc::clone(&app_data));
+        Picker::new_picker(app_data, worker, width, behaviour)
     }
 
     /// Updates the list of discovered namespaces.
@@ -23,20 +25,20 @@ impl NamespaceSelector {
 }
 
 pub struct NamespaceBehaviour {
+    app_data: SharedAppData,
     discovered: Vec<String>,
     validator: InputValidator,
 }
 
-impl Default for NamespaceBehaviour {
-    fn default() -> Self {
+impl NamespaceBehaviour {
+    pub fn new(app_data: SharedAppData) -> Self {
         Self {
+            app_data,
             discovered: Vec::new(),
             validator: InputValidator::new(ValidatorKind::Namespace),
         }
     }
-}
 
-impl NamespaceBehaviour {
     /// Updates the list of discovered namespaces.
     pub fn set_discovered(&mut self, namespaces: Vec<String>) {
         self.discovered = namespaces;
@@ -48,8 +50,8 @@ impl PickerBehaviour for NamespaceBehaviour {
         "namespace "
     }
 
-    fn colors(&self, app_data: &SharedAppData) -> SelectColors {
-        app_data.borrow().theme.colors.command_palette.clone()
+    fn colors(&self) -> SelectColors {
+        self.app_data.borrow().theme.colors.command_palette.clone()
     }
 
     fn reset_key_command(&self) -> KeyCommand {
@@ -60,10 +62,10 @@ impl PickerBehaviour for NamespaceBehaviour {
         ResponseEvent::Cancelled
     }
 
-    fn load_items(&self, app_data: &SharedAppData) -> PatternsList {
-        let key_name = app_data.get_key_name(KeyCommand::NavigateComplete).to_ascii_uppercase();
-        let context = &app_data.borrow().current.context;
-        let mut items = PatternsList::from(app_data.borrow().history.namespace_history(context), Some(&key_name));
+    fn load_items(&self) -> PatternsList {
+        let key_name = self.app_data.get_key_name(KeyCommand::NavigateComplete).to_ascii_uppercase();
+        let context = &self.app_data.borrow().current.context;
+        let mut items = PatternsList::from(self.app_data.borrow().history.namespace_history(context), Some(&key_name));
         for item in items.list.full_iter_mut() {
             item.data.icon = Some("");
         }
@@ -75,17 +77,17 @@ impl PickerBehaviour for NamespaceBehaviour {
         items
     }
 
-    fn add_item(&self, app_data: &SharedAppData, item: &str) {
-        let context = app_data.borrow().current.context.clone();
-        app_data
+    fn add_item(&self, item: &str) {
+        let context = self.app_data.borrow().current.context.clone();
+        self.app_data
             .borrow_mut()
             .history
             .put_namespace_history_item(&context, item.into(), NAMESPACE_HISTORY_SIZE);
     }
 
-    fn remove_item(&self, app_data: &SharedAppData, item: &str) -> bool {
-        let context = app_data.borrow().current.context.clone();
-        app_data
+    fn remove_item(&self, item: &str) -> bool {
+        let context = self.app_data.borrow().current.context.clone();
+        self.app_data
             .borrow_mut()
             .history
             .remove_namespace_history_item(&context, item)

--- a/b4n/ui/widgets/pickers/namespace.rs
+++ b/b4n/ui/widgets/pickers/namespace.rs
@@ -112,11 +112,7 @@ impl PickerBehaviour for NamespaceBehaviour {
         true
     }
 
-    fn has_header(&self) -> bool {
-        false
-    }
-
-    fn get_response(&self, pattern: &str, highlighted: Option<&str>) -> ResponseEvent {
+    fn navigate_into(&self, pattern: &str, highlighted: Option<&str>) -> ResponseEvent {
         if pattern.is_empty()
             && let Some(highlighted) = highlighted
         {
@@ -126,5 +122,9 @@ impl PickerBehaviour for NamespaceBehaviour {
         } else {
             ResponseEvent::Handled
         }
+    }
+
+    fn has_header(&self) -> bool {
+        false
     }
 }

--- a/b4n/ui/widgets/pickers/search.rs
+++ b/b4n/ui/widgets/pickers/search.rs
@@ -5,6 +5,7 @@ use b4n_tui::{ResponseEvent, table::Table};
 use ratatui::layout::{Position, Rect};
 use ratatui::style::Style;
 use ratatui::widgets::Paragraph;
+use std::rc::Rc;
 
 use crate::core::{SharedAppData, SharedAppDataExt, SharedBgWorker};
 use crate::ui::widgets::{PatternsList, Picker, PickerBehaviour};
@@ -16,7 +17,7 @@ pub type Search = Picker<SearchBehaviour>;
 impl Search {
     /// Creates new [`Search`] instance.
     pub fn new(app_data: SharedAppData, worker: Option<SharedBgWorker>, width: u16) -> Self {
-        let behaviour = SearchBehaviour::new(&app_data);
+        let behaviour = SearchBehaviour::new(Rc::clone(&app_data));
         Picker::new_picker(app_data, worker, width, behaviour)
     }
 
@@ -37,6 +38,7 @@ impl Search {
 }
 
 pub struct SearchBehaviour {
+    app_data: SharedAppData,
     hint: String,
     matches: Option<usize>,
     highlight_position: Option<Position>,
@@ -44,12 +46,13 @@ pub struct SearchBehaviour {
 
 impl SearchBehaviour {
     /// Creates new [`SearchBehaviour`] instance.
-    pub fn new(app_data: &SharedAppData) -> Self {
+    pub fn new(app_data: SharedAppData) -> Self {
         let enter = app_data.get_key_name(KeyCommand::NavigateInto).to_ascii_uppercase();
         let next = app_data.get_key_name(KeyCommand::MatchNext).to_ascii_uppercase();
         let prev = app_data.get_key_name(KeyCommand::MatchPrevious).to_ascii_uppercase();
 
         Self {
+            app_data,
             hint: format!(" {enter} to accept, {next} and {prev} to navigate."),
             matches: None,
             highlight_position: None,
@@ -77,8 +80,8 @@ impl PickerBehaviour for SearchBehaviour {
         " "
     }
 
-    fn colors(&self, app_data: &SharedAppData) -> SelectColors {
-        app_data.borrow().theme.colors.search.clone()
+    fn colors(&self) -> SelectColors {
+        self.app_data.borrow().theme.colors.search.clone()
     }
 
     fn reset_key_command(&self) -> KeyCommand {
@@ -89,23 +92,23 @@ impl PickerBehaviour for SearchBehaviour {
         ResponseEvent::Handled
     }
 
-    fn load_items(&self, app_data: &SharedAppData) -> PatternsList {
-        let context = &app_data.borrow().current.context;
-        let key_name = app_data.get_key_name(KeyCommand::NavigateComplete).to_ascii_uppercase();
-        PatternsList::from(app_data.borrow().history.search_history(context), Some(&key_name))
+    fn load_items(&self) -> PatternsList {
+        let context = &self.app_data.borrow().current.context;
+        let key_name = self.app_data.get_key_name(KeyCommand::NavigateComplete).to_ascii_uppercase();
+        PatternsList::from(self.app_data.borrow().history.search_history(context), Some(&key_name))
     }
 
-    fn add_item(&self, app_data: &SharedAppData, item: &str) {
-        let context = app_data.borrow().current.context.clone();
-        app_data
+    fn add_item(&self, item: &str) {
+        let context = self.app_data.borrow().current.context.clone();
+        self.app_data
             .borrow_mut()
             .history
             .put_search_history_item(&context, item.into(), SEARCH_HISTORY_SIZE);
     }
 
-    fn remove_item(&self, app_data: &SharedAppData, item: &str) -> bool {
-        let context = app_data.borrow().current.context.clone();
-        app_data
+    fn remove_item(&self, item: &str) -> bool {
+        let context = self.app_data.borrow().current.context.clone();
+        self.app_data
             .borrow_mut()
             .history
             .remove_search_history_item(&context, item)


### PR DESCRIPTION
This PR adds pinning to the resources view filtering. It is now possible to pin active filter with `Ctrl+P`. If filter is pinned it will be active after resource kind change.