### PR TITLE
Respect filtering in stop stale forwarding rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 - run save configuration tasks sequentially
 - fix pasting clipboard text containing non-ASCII characters
-- preserve filter on ports forward list update
+- preserve filter on port forward list update
 
 ### Compatibility
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## WIP
+## 0.4.6 - 2026-04-08
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - run save configuration tasks sequentially
 - fix pasting clipboard text containing non-ASCII characters
+- preserve filter on ports forward list update
 
 ### Compatibility
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,7 +185,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "b4n"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "ansi-to-tui",
  "anyhow",
@@ -215,7 +215,7 @@ dependencies = [
 
 [[package]]
 name = "b4n-common"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "anyhow",
  "sha1",
@@ -230,7 +230,7 @@ dependencies = [
 
 [[package]]
 name = "b4n-config"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "anyhow",
  "b4n-common",
@@ -248,7 +248,7 @@ dependencies = [
 
 [[package]]
 name = "b4n-kube"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "b4n-common",
  "base64",
@@ -267,7 +267,7 @@ dependencies = [
 
 [[package]]
 name = "b4n-list"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "crossterm 0.29.0",
  "k8s-openapi",
@@ -275,7 +275,7 @@ dependencies = [
 
 [[package]]
 name = "b4n-tasks"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "b4n-common",
  "b4n-config",
@@ -295,7 +295,7 @@ dependencies = [
 
 [[package]]
 name = "b4n-tui"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "anyhow",
  "b4n-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.5"
+version = "0.4.6"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -31,24 +31,27 @@ The resulting binary will be available at `./target/release/b4n`.
 
 The following features are currently supported:
 
-- View a list of Kubernetes resources.
+- View and filter a list of Kubernetes resources.
 - Create, read, update and delete Kubernetes resources.
 - View events for the highlighted resource.
 - View logs for the highlighted pod or container.
-- Open a shell session in the highlighted container.
+- Open a shell session / attach to the highlighted container main process.
 - Enable port forwarding for the highlighted container.
+- Mouse support in all views.
 
 ### Planned
 
 The following features are planned for future development:
 
-- Allow custom commands (simple plugin system to run external binaries).
+- File transfer from / to a pod.
+- Custom commands (simple plugin system to run external binaries).
 - Describe Kubernetes resources.
 
 ## Default Key Bindings
 
 | Action                                    | Command         | Comments                                                    |
 |:------------------------------------------|:----------------|:------------------------------------------------------------|
+| Attach to the container's main process    | `a`             | Works only in containers view                               |
 | Attach to the container's shell           | `s`             | Works only in containers view                               |
 | Copy YAML / logs / resources to clipboard | `c`             | Works only in YAML, logs and resources views                |
 | Create new resource                       | `n`             |                                                             |
@@ -60,7 +63,8 @@ The following features are planned for future development:
 | Navigate to the involved object           | `i`             | Works only for `events` kind                                |
 | Open / switch to the edit mode            | `i`             | Press `Esc` to exit, then `Esc` for save dialog             |
 | Open right mouse button menu              | `m`             | Navigate using `↑` or `↓`                                   |
-| Quit the application                      | `CTRL` + `c`    |                                                             |
+| Pin active filter across resources        | `CTRL` + `p`    | Works also in the filter dialog                             |
+| Quit the application                      | `CTRL` + `c`    | No confirmation dialog                                      |
 | Reverse selection                         | `CTRL` + ` `    | (`CTRL` + `SPACE`)                                          |
 | Select resource                           | ` `             | (`SPACE`)                                                   |
 | Show / hide log timestamps                | `t`             | Works only in logs view                                     |
@@ -115,7 +119,8 @@ contexts:
   production: '#d8d8d8:#e1140a'
 aliases:
   daemonsets: ds,dms
-  namespaces: ns
+  namespace: nn
+  namespaces: ns,na,nam
   services: svc
 key_bindings:
   action.name: list of key bindings for that action

--- a/b4n-tasks/forwarder.rs
+++ b/b4n-tasks/forwarder.rs
@@ -1,10 +1,11 @@
 use b4n_common::{DEFAULT_ERROR_DURATION, NotificationSink};
 use b4n_kube::client::KubernetesClient;
-use b4n_kube::stats::SharedStatistics;
-use b4n_kube::{PODS, ResourceRef};
+use b4n_kube::stats::{SharedStatistics, Statistics};
+use b4n_kube::{ContainerRef, PODS, ResourceRef};
 use k8s_openapi::api::core::v1::Pod;
 use k8s_openapi::jiff::Timestamp;
 use kube::Api;
+use std::cell::Ref;
 use std::error::Error;
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -147,15 +148,11 @@ impl PortForwarder {
         while self.events_rx.try_recv().is_ok() {}
     }
 
-    /// Stops all tasks for pods that are not on the statistics list.
-    pub fn stop_stale_pod_tasks(&mut self, statistics: &SharedStatistics) {
+    /// Stops all (or from specified list) port forwarding tasks for pods that no longer exist.
+    pub fn stop_stale_pod_tasks(&mut self, filtered: Option<&[ContainerRef]>, statistics: &SharedStatistics) {
         let statistics = statistics.borrow();
         for task in &mut self.tasks {
-            if !statistics.exists(
-                task.resource.name.as_deref().unwrap_or_default(),
-                task.resource.namespace.as_str(),
-                task.resource.container.as_deref(),
-            ) {
+            if task.is_in_filter(filtered) && !task.exists_in_statistics(&statistics) {
                 task.cancel();
             }
         }
@@ -279,6 +276,26 @@ impl PortForwardTask {
     fn stop(&mut self) {
         self.cancel();
         b4n_common::tasks::wait_for_task(self.task.take(), "port forward");
+    }
+
+    /// Returns `true` if task is on the specified list.\
+    /// **Note** that it returns also `true` if list is `None`.
+    fn is_in_filter(&self, list: Option<&[ContainerRef]>) -> bool {
+        list.is_none_or(|l| l.iter().any(|i| self.matches_ref(i)))
+    }
+
+    fn exists_in_statistics(&self, statistics: &Ref<'_, Statistics>) -> bool {
+        statistics.exists(
+            self.resource.name.as_deref().unwrap_or_default(),
+            self.resource.namespace.as_str(),
+            self.resource.container.as_deref(),
+        )
+    }
+
+    fn matches_ref(&self, i: &ContainerRef) -> bool {
+        i.name == self.resource.name.as_deref().unwrap_or_default()
+            && i.namespace == self.resource.namespace
+            && i.container == self.resource.container
     }
 }
 

--- a/b4n-tasks/tasks/executor.rs
+++ b/b4n-tasks/tasks/executor.rs
@@ -5,10 +5,8 @@ use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
-use crate::tasks::run_command;
+use crate::tasks::{PendingTask, run_command};
 use crate::{BgTask, TaskResult, commands::Command};
-
-type SequentialTask = (String, Command, CancellationToken);
 
 /// Background commands executor.
 pub struct BgExecutor {
@@ -19,7 +17,7 @@ pub struct BgExecutor {
     sequential_worker: Option<JoinHandle<()>>,
     sequential_token: CancellationToken,
     sequential_drain: Arc<AtomicBool>,
-    sequential_tx: UnboundedSender<SequentialTask>,
+    sequential_tx: UnboundedSender<PendingTask>,
 }
 
 impl BgExecutor {
@@ -47,38 +45,6 @@ impl BgExecutor {
         }
     }
 
-    /// Worker that processes commands one by one in order.
-    async fn sequential_worker(
-        mut rx: UnboundedReceiver<SequentialTask>,
-        results_tx: UnboundedSender<Box<TaskResult>>,
-        drain: Arc<AtomicBool>,
-    ) {
-        while let Some((task_id, command, cancellation_token)) = rx.recv().await {
-            if drain.load(Ordering::Relaxed) {
-                while rx.try_recv().is_ok() {}
-                drain.store(false, Ordering::Relaxed);
-                continue;
-            }
-
-            let result = tokio::select! {
-                () = cancellation_token.cancelled() => {
-                    if drain.load(Ordering::Relaxed) {
-                        while rx.try_recv().is_ok() {}
-                        drain.store(false, Ordering::Relaxed);
-                    }
-                    continue;
-                },
-                result = run_command(command) => result,
-            };
-
-            if let Some(result) = result
-                && let Err(error) = results_tx.send(Box::new(TaskResult { id: task_id, result }))
-            {
-                tracing::warn!("Cannot send sequential task result: {}", error);
-            }
-        }
-    }
-
     /// Creates a task with the specified command and runs it.\
     /// **Note** that it returns a unique task ID by which the task can be canceled.
     pub fn run_task(&mut self, command: Command) -> String {
@@ -86,9 +52,9 @@ impl BgExecutor {
             return self.enqueue_sequential(command);
         }
 
-        let mut task = BgTask::new(command);
-        task.run(&self.runtime, self.results_tx.clone());
-        let id = task.id().to_owned();
+        let pending = PendingTask::new(command, CancellationToken::new());
+        let id = pending.id.clone();
+        let task = BgTask::run(pending, &self.runtime, self.results_tx.clone());
         self.tasks.push(task);
         self.cleanup_finished();
 
@@ -140,15 +106,44 @@ impl BgExecutor {
         self.results_rx.try_recv().ok()
     }
 
+    /// Worker that processes commands one by one in order.
+    async fn sequential_worker(
+        mut rx: UnboundedReceiver<PendingTask>,
+        results_tx: UnboundedSender<Box<TaskResult>>,
+        drain: Arc<AtomicBool>,
+    ) {
+        while let Some(pending) = rx.recv().await {
+            if drain.load(Ordering::Relaxed) {
+                while rx.try_recv().is_ok() {}
+                drain.store(false, Ordering::Relaxed);
+                continue;
+            }
+
+            let result = tokio::select! {
+                () = pending.cancellation_token.cancelled() => {
+                    if drain.load(Ordering::Relaxed) {
+                        while rx.try_recv().is_ok() {}
+                        drain.store(false, Ordering::Relaxed);
+                    }
+                    continue;
+                },
+                result = run_command(pending.command) => result,
+            };
+
+            if let Some(result) = result
+                && let Err(error) = results_tx.send(Box::new(TaskResult { id: pending.id, result }))
+            {
+                tracing::warn!("Cannot send sequential task result: {}", error);
+            }
+        }
+    }
+
     /// Enqueues a command for sequential execution.
     fn enqueue_sequential(&self, command: Command) -> String {
-        let id = uuid::Uuid::new_v4()
-            .hyphenated()
-            .encode_lower(&mut uuid::Uuid::encode_buffer())
-            .to_owned();
+        let pending = PendingTask::new(command, self.sequential_token.clone());
+        let id = pending.id.clone();
 
-        let token = self.sequential_token.clone();
-        if let Err(error) = self.sequential_tx.send((id.clone(), command, token)) {
+        if let Err(error) = self.sequential_tx.send(pending) {
             tracing::warn!("Cannot enqueue sequential command: {}", error);
         }
 

--- a/b4n-tasks/tasks/task.rs
+++ b/b4n-tasks/tasks/task.rs
@@ -4,50 +4,58 @@ use uuid::Uuid;
 
 use crate::commands::{Command, CommandResult};
 
+/// Result from the executed task.
 pub struct TaskResult {
     pub id: String,
     pub result: CommandResult,
 }
 
+/// A task that has been created but not yet started.
+pub struct PendingTask {
+    pub id: String,
+    pub command: Command,
+    pub cancellation_token: CancellationToken,
+}
+
+impl PendingTask {
+    /// Creates new [`PendingTask`] instance.
+    pub fn new(command: Command, cancellation_token: CancellationToken) -> Self {
+        Self {
+            id: Uuid::new_v4()
+                .hyphenated()
+                .encode_lower(&mut Uuid::encode_buffer())
+                .to_owned(),
+            command,
+            cancellation_token,
+        }
+    }
+}
+
 /// Background task for background executor.
 pub struct BgTask {
-    uuid: String,
-    command: Option<Command>,
+    id: String,
     task: Option<JoinHandle<()>>,
     cancellation_token: Option<CancellationToken>,
 }
 
 impl BgTask {
-    /// Creates new [`BgTask`] instance.\
-    /// **Note** that it must be run in order to start execute a command.
-    pub fn new(command: Command) -> Self {
-        Self {
-            uuid: Uuid::new_v4()
-                .hyphenated()
-                .encode_lower(&mut Uuid::encode_buffer())
-                .to_owned(),
-            command: Some(command),
-            task: None,
-            cancellation_token: None,
-        }
-    }
+    /// Creates and immediately starts executing the given [`PendingTask`].
+    pub fn run(pending: PendingTask, runtime: &Handle, results_tx: UnboundedSender<Box<TaskResult>>) -> Self {
+        let PendingTask {
+            id,
+            command,
+            cancellation_token,
+        } = pending;
 
-    /// Starts executing an associated command.
-    pub fn run(&mut self, runtime: &Handle, results_tx: UnboundedSender<Box<TaskResult>>) {
-        let Some(_command) = self.command.take() else {
-            return;
-        };
-
-        let cancellation_token = CancellationToken::new();
-        let _cancellation_token = cancellation_token.clone();
-        let _task_id = self.id().to_owned();
+        let token = cancellation_token.clone();
+        let task_id = id.clone();
 
         let task = runtime.spawn(async move {
             tokio::select! {
-                () = _cancellation_token.cancelled() => (),
-                result = run_command(_command) => {
+                () = token.cancelled() => (),
+                result = run_command(command) => {
                     if let Some(result) = result
-                        && let Err(error) = results_tx.send(Box::new(TaskResult { id: _task_id, result }))
+                        && let Err(error) = results_tx.send(Box::new(TaskResult { id: task_id, result }))
                     {
                         tracing::warn!("Cannot send task result: {}", error);
                     }
@@ -55,13 +63,16 @@ impl BgTask {
             }
         });
 
-        self.task = Some(task);
-        self.cancellation_token = Some(cancellation_token);
+        Self {
+            id,
+            task: Some(task),
+            cancellation_token: Some(cancellation_token),
+        }
     }
 
     /// Unique task ID.
     pub fn id(&self) -> &str {
-        &self.uuid
+        &self.id
     }
 
     /// Indicates if the task is currently running.
@@ -69,15 +80,15 @@ impl BgTask {
         self.task.as_ref().is_some_and(|t| !t.is_finished())
     }
 
-    /// Indicates if the task was started and is currently in a finished state.
+    /// Indicates if the task is currently in a finished state.
     pub fn is_finished(&self) -> bool {
-        self.command.is_none() && !self.is_running()
+        !self.is_running()
     }
 
     /// Cancels [`BgTask`] task.
     pub fn cancel(&mut self) {
-        if let Some(cancellation_token) = self.cancellation_token.take() {
-            cancellation_token.cancel();
+        if let Some(token) = self.cancellation_token.take() {
+            token.cancel();
         }
     }
 

--- a/b4n/core/worker.rs
+++ b/b4n/core/worker.rs
@@ -5,7 +5,7 @@ use b4n_kube::client::KubernetesClient;
 use b4n_kube::crds::{CrdObserver, SharedCrdsList};
 use b4n_kube::stats::BgStatistics;
 use b4n_kube::utils::{get_plural, get_resource};
-use b4n_kube::{BgDiscovery, BgObserverError, CRDS, DiscoveryList, Kind, NAMESPACES, Namespace, PODS, ResourceRef};
+use b4n_kube::{BgDiscovery, BgObserverError, CRDS, ContainerRef, DiscoveryList, Kind, NAMESPACES, Namespace, PODS, ResourceRef};
 use b4n_tasks::commands::{
     Command, DeleteResourcesCommand, DeleteResourcesOptions, GetNewResourceYamlCommand, GetResourceYamlCommand,
     ListResourcePortsCommand, SaveConfigurationCommand, SetNewResourceYamlCommand, SetNewResourceYamlOptions,
@@ -468,10 +468,10 @@ impl BgWorker {
         }
     }
 
-    /// Stops all port forwarding tasks for pods that no longer exist.
-    pub fn stop_stale_port_forwards(&mut self) {
+    /// Stops all (or from specified list) port forwarding tasks for pods that no longer exist.
+    pub fn stop_stale_port_forwards(&mut self, filtered: Option<&[ContainerRef]>) {
         if !self.statistics.has_error() {
-            self.forwarder.stop_stale_pod_tasks(self.statistics.stats());
+            self.forwarder.stop_stale_pod_tasks(filtered, self.statistics.stats());
         }
     }
 }

--- a/b4n/ui/views/forwards/item.rs
+++ b/b4n/ui/views/forwards/item.rs
@@ -1,6 +1,7 @@
 use b4n_common::expr::{Expression, ExpressionExt, SelectiveMap, parse};
 use b4n_common::truncate;
 use b4n_config::themes::{TextColors, Theme};
+use b4n_kube::ContainerRef;
 use b4n_list::{FilterContext, Filterable, Row};
 use b4n_tasks::PortForwardTask;
 use k8s_openapi::jiff::Timestamp;
@@ -11,6 +12,7 @@ pub struct PortForwardItem {
     pub uid: String,
     group: String,
     name: String,
+    container: Option<String>,
     age: Option<String>,
     creation_timestamp: Option<Timestamp>,
     bind_address: String,
@@ -37,6 +39,7 @@ impl PortForwardItem {
             uid: task.uuid.clone(),
             group: task.resource.namespace.as_str().to_owned(),
             name: task.resource.name.as_deref().unwrap_or_default().to_owned(),
+            container: task.resource.container.clone(),
             age: task.start_time.as_ref().map(|t| t.as_millisecond().to_string()),
             creation_timestamp: task.start_time,
             bind_address: task.bind_address.clone(),
@@ -105,6 +108,12 @@ impl Row for PortForwardItem {
             7 => self.age.as_deref().unwrap_or("n/a"),
             _ => "n/a",
         }
+    }
+}
+
+impl From<&PortForwardItem> for ContainerRef {
+    fn from(value: &PortForwardItem) -> Self {
+        Self::simple(value.name.clone(), value.group.as_str().into(), value.container.clone())
     }
 }
 

--- a/b4n/ui/views/forwards/list.rs
+++ b/b4n/ui/views/forwards/list.rs
@@ -28,12 +28,12 @@ impl PortForwardsList {
         let (sort_by, is_descending) = self.table.header.sort_info();
         let highlighted_uid = self.table.list.get_highlighted_item_uid().map(String::from);
         let selected_uids: Vec<_> = self.table.list.get_selected_uids().iter().map(|&u| u.to_owned()).collect();
+        let filter = self.table.list.filter().map(String::from);
 
-        self.table
-            .list
-            .set_items(items.into_iter().map(Item::new).collect::<Vec<_>>());
+        self.table.list.set_items(items.into_iter().map(Item::new).collect());
         self.table.sort(sort_by, is_descending);
         self.table.update_data_lengths();
+        self.table.list.set_filter(filter);
 
         self.table.list.select_uids(selected_uids.as_slice());
         if let Some(uid) = highlighted_uid {

--- a/b4n/ui/views/forwards/list.rs
+++ b/b4n/ui/views/forwards/list.rs
@@ -1,4 +1,5 @@
 use b4n_config::themes::{TextColors, Theme};
+use b4n_kube::ContainerRef;
 use b4n_list::Item;
 use b4n_tui::table::{Column, Header, ItemExt, NAMESPACE, TabularList, ViewType};
 use b4n_tui::{ResponseEvent, Responsive, TuiEvent, table::Table};
@@ -38,6 +39,11 @@ impl PortForwardsList {
         if let Some(uid) = highlighted_uid {
             self.table.list.highlight_item_by_uid(&uid);
         }
+    }
+
+    /// Copies filtered `self` into a new `Vec` of `ContainerRef`.
+    pub fn to_container_vec(&self) -> Vec<ContainerRef> {
+        self.table.list.iter().map(|i| (&i.data).into()).collect()
     }
 }
 

--- a/b4n/ui/views/forwards/view.rs
+++ b/b4n/ui/views/forwards/view.rs
@@ -124,7 +124,12 @@ impl ForwardsView {
                 builder.add_menu_action(ActionItem::menu(1, " stop ␝selected␝", "stop_selected"));
             }
 
-            builder.add_menu_action(ActionItem::menu(2, " stop ␝stale␝", "cleanup"));
+            let caption = if self.list.table.is_filtered() {
+                " stop ␝stale []␝"
+            } else {
+                " stop ␝stale␝"
+            };
+            builder.add_menu_action(ActionItem::menu(2, caption, "cleanup"));
         }
 
         self.command_palette = CommandPalette::new(Rc::clone(&self.app_data), builder.build(None), 22).to_mouse_menu();
@@ -174,19 +179,32 @@ impl ForwardsView {
         }
     }
 
-    /// Stops all stale port forwarding rules.
+    /// Stops stale port forwarding rules.\
+    /// **Note** that it stops only visible (full or filtered list) tasks.
     fn stop_stale_port_forwards(&mut self) {
-        self.worker.borrow_mut().stop_stale_port_forwards();
-        self.footer_tx
-            .show_info("All stale port forwarding rules have been stopped", 3_000);
+        if !self.list.table.is_filtered() && self.namespace.is_all() {
+            self.worker.borrow_mut().stop_stale_port_forwards(None);
+            self.footer_tx
+                .show_info("All stale port forwarding rules have been stopped", 3_000);
+        } else {
+            let filtered = Some(self.list.table.to_container_vec());
+            self.worker.borrow_mut().stop_stale_port_forwards(filtered.as_deref());
+            self.footer_tx
+                .show_info("Stale port forwarding rules stopped for pods in current view", 3_000);
+        };
     }
 
     /// Creates new cleanup stale pods dialog.
     fn new_cleanup_dialog(&mut self) -> Dialog {
         let colors = &self.app_data.borrow().theme.colors;
+        let kind = if !self.list.table.is_filtered() && self.namespace.is_all() {
+            "all"
+        } else {
+            "visible"
+        };
 
         Dialog::new(
-            "Are you sure you want to stop all port forwarding rules for pods that no longer exist? ".to_owned(),
+            format!("Are you sure you want to stop {kind} port forwarding rules for pods that no longer exist? "),
             vec![
                 Button::new("Stop", ResponseEvent::Action("cleanup"), &colors.modal.btn_delete),
                 Button::new("Cancel", ResponseEvent::Cancelled, &colors.modal.btn_cancel),
@@ -254,10 +272,23 @@ impl View for ForwardsView {
     }
 
     fn handle_namespace_change(&mut self) {
-        (self.namespace, self.list.view) = get_current_namespace(&self.app_data);
+        let (namespace, view) = get_current_namespace(&self.app_data);
+        if self.namespace == namespace {
+            return;
+        }
+
+        self.namespace = namespace;
+        self.list.view = view;
         self.list
             .table
             .update(self.worker.borrow_mut().get_port_forwards_list(&self.namespace));
+
+        if !self.app_data.borrow().is_pinned {
+            self.set_filter(String::new());
+        } else {
+            self.update_filter();
+        }
+
         self.header.set_count(self.list.table.len());
         self.header.set_namespace(self.namespace.as_option());
     }

--- a/b4n/ui/views/forwards/view.rs
+++ b/b4n/ui/views/forwards/view.rs
@@ -191,7 +191,7 @@ impl ForwardsView {
             self.worker.borrow_mut().stop_stale_port_forwards(filtered.as_deref());
             self.footer_tx
                 .show_info("Stale port forwarding rules stopped for pods in current view", 3_000);
-        };
+        }
     }
 
     /// Creates new cleanup stale pods dialog.
@@ -283,10 +283,10 @@ impl View for ForwardsView {
             .table
             .update(self.worker.borrow_mut().get_port_forwards_list(&self.namespace));
 
-        if !self.app_data.borrow().is_pinned {
-            self.set_filter(String::new());
-        } else {
+        if self.app_data.borrow().is_pinned {
             self.update_filter();
+        } else {
+            self.set_filter(String::new());
         }
 
         self.header.set_count(self.list.table.len());

--- a/b4n/ui/views/resources/view.rs
+++ b/b4n/ui/views/resources/view.rs
@@ -4,7 +4,7 @@ use b4n_kube::stats::SharedStatistics;
 use b4n_kube::{
     ALL_NAMESPACES, CONTAINERS, EVENTS, Kind, NAMESPACES, NODES, Namespace, ObserverResult, PODS, Port, ResourceRef, SECRETS,
 };
-use b4n_tui::widgets::{ActionItem, ActionsListBuilder, Button, CheckBox, Dialog, Selector, ValidatorKind};
+use b4n_tui::widgets::{ActionItem, ActionsList, ActionsListBuilder, Button, CheckBox, Dialog, Selector, ValidatorKind};
 use b4n_tui::{MouseEventKind, ResponseEvent, Responsive, ScopeData, TuiEvent, table::Table, table::ViewType};
 use delegate::delegate;
 use kube::{config::NamedContext, discovery::Scope};
@@ -277,10 +277,8 @@ impl ResourcesView {
             let actions = ActionsListBuilder::default()
                 .with_resources_actions(false)
                 .build(Some(&self.app_data.borrow().key_bindings));
-            self.command_palette = CommandPalette::new(Rc::clone(&self.app_data), actions, 65)
-                .with_highlighted_position(self.last_mouse_click.take());
-            self.command_palette.show();
-            self.footer_tx.hide_hint();
+
+            self.open_command_palette(actions);
             return;
         }
 
@@ -340,70 +338,84 @@ impl ResourcesView {
         }
 
         if is_highlighted {
-            builder.add_action(
-                ActionItem::action("show YAML", "show_yaml")
-                    .with_description(if is_containers {
-                        "shows YAML of the container's resource"
-                    } else {
-                        "shows YAML of the highlighted resource"
-                    })
-                    .with_aliases(&["yaml", "yml", "view"]),
-                Some(KeyCommand::YamlOpen),
-            );
-
+            builder = self.add_resource_actions(builder, is_containers);
             if is_containers || is_pods {
-                builder = builder
-                    .with_action(
-                        ActionItem::action("show logs", "show_logs")
-                            .with_description("shows container logs")
-                            .with_aliases(&["logs"]),
-                        Some(KeyCommand::LogsOpen),
-                    )
-                    .with_action(
-                        ActionItem::action("show previous logs", "show_plogs")
-                            .with_description("shows container previous logs")
-                            .with_aliases(&["previous"]),
-                        Some(KeyCommand::PreviousLogsOpen),
-                    )
-                    .with_action(
-                        ActionItem::action("attach", "attach").with_description("attaches to container main process"),
-                        Some(KeyCommand::ContainerAttach),
-                    )
-                    .with_action(
-                        ActionItem::action("shell", "open_shell").with_description("opens container shell"),
-                        Some(KeyCommand::ShellOpen),
-                    )
-                    .with_action(
-                        ActionItem::action("forward port", "port_forward")
-                            .with_description("forwards container port")
-                            .with_aliases(&["port", "pf"]),
-                        Some(KeyCommand::PortForwardsCreate),
-                    );
-            }
-
-            if self.table.kind_plural() == SECRETS {
-                builder.add_action(
-                    ActionItem::action("decode", "decode_yaml").with_description("shows decoded YAML of the highlighted secret"),
-                    Some(KeyCommand::YamlDecode),
-                );
-            }
-
-            if self.table.list.table.data.is_editable {
-                builder.add_action(
-                    ActionItem::action("edit YAML", "edit_yaml")
-                        .with_description("displays YAML and switches to edit mode")
-                        .with_aliases(&["yaml", "yml", "patch"]),
-                    Some(KeyCommand::YamlEdit),
-                );
+                builder = Self::add_container_actions(builder);
             }
         }
 
         builder = builder.with_aliases(&self.app_data.borrow().config.aliases);
         let actions = builder.build(Some(&self.app_data.borrow().key_bindings));
+
+        self.open_command_palette(actions);
+    }
+
+    fn open_command_palette(&mut self, actions: ActionsList) {
         self.command_palette =
             CommandPalette::new(Rc::clone(&self.app_data), actions, 65).with_highlighted_position(self.last_mouse_click.take());
         self.command_palette.show();
         self.footer_tx.hide_hint();
+    }
+
+    fn add_resource_actions(&self, mut builder: ActionsListBuilder, is_containers: bool) -> ActionsListBuilder {
+        builder.add_action(
+            ActionItem::action("show YAML", "show_yaml")
+                .with_description(if is_containers {
+                    "shows YAML of the container's resource"
+                } else {
+                    "shows YAML of the highlighted resource"
+                })
+                .with_aliases(&["yaml", "yml", "view"]),
+            Some(KeyCommand::YamlOpen),
+        );
+
+        if self.table.kind_plural() == SECRETS {
+            builder.add_action(
+                ActionItem::action("decode", "decode_yaml").with_description("shows decoded YAML of the highlighted secret"),
+                Some(KeyCommand::YamlDecode),
+            );
+        }
+
+        if self.table.list.table.data.is_editable {
+            builder.add_action(
+                ActionItem::action("edit YAML", "edit_yaml")
+                    .with_description("displays YAML and switches to edit mode")
+                    .with_aliases(&["yaml", "yml", "patch"]),
+                Some(KeyCommand::YamlEdit),
+            );
+        }
+
+        builder
+    }
+
+    fn add_container_actions(builder: ActionsListBuilder) -> ActionsListBuilder {
+        builder
+            .with_action(
+                ActionItem::action("show logs", "show_logs")
+                    .with_description("shows container logs")
+                    .with_aliases(&["logs"]),
+                Some(KeyCommand::LogsOpen),
+            )
+            .with_action(
+                ActionItem::action("show previous logs", "show_plogs")
+                    .with_description("shows container previous logs")
+                    .with_aliases(&["previous"]),
+                Some(KeyCommand::PreviousLogsOpen),
+            )
+            .with_action(
+                ActionItem::action("attach", "attach").with_description("attaches to container main process"),
+                Some(KeyCommand::ContainerAttach),
+            )
+            .with_action(
+                ActionItem::action("shell", "open_shell").with_description("opens container shell"),
+                Some(KeyCommand::ShellOpen),
+            )
+            .with_action(
+                ActionItem::action("forward port", "port_forward")
+                    .with_description("forwards container port")
+                    .with_aliases(&["port", "pf"]),
+                Some(KeyCommand::PortForwardsCreate),
+            )
     }
 
     fn show_mouse_menu(&mut self, x: u16, y: u16) {


### PR DESCRIPTION
This PR changes behaviour of stop stale in port forward view. From now cleanup is done only on the visible items (filtering and namespaces are respected).