### PR TITLE
Fix backspace and enter keys in attach view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## WIP
+
+### Bug fixes
+
+- fix `Backspace` and `Enter` keys in attach view
+
 ## 0.4.6 - 2026-04-08
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ The resulting binary will be available at `./target/release/b4n`.
 The following features are currently supported:
 
 - View and filter a list of Kubernetes resources.
-- Create, read, update and delete Kubernetes resources.
+- Create, read, update, and delete Kubernetes resources.
 - View events for the highlighted resource.
 - View logs for the highlighted pod or container.
-- Open a shell session / attach to the highlighted container main process.
+- Open a shell session or attach to the highlighted container's main process.
 - Enable port forwarding for the highlighted container.
 - Mouse support in all views.
 
@@ -43,7 +43,7 @@ The following features are currently supported:
 
 The following features are planned for future development:
 
-- File transfer from / to a pod.
+- File transfer from/to a pod.
 - Custom commands (simple plugin system to run external binaries).
 - Describe Kubernetes resources.
 
@@ -61,9 +61,9 @@ The following features are planned for future development:
 | Forward container's port                  | `f`             | Works only in containers view                               |
 | Go back to namespaces; clear filter       | `ESC`           | Also clears input in the filter widget                      |
 | Navigate to the involved object           | `i`             | Works only for `events` kind                                |
-| Open / switch to the edit mode            | `i`             | Press `Esc` to exit, then `Esc` for save dialog             |
+| Open / switch to edit mode                | `i`             | Press `ESC` to exit, then `ESC` for save dialog             |
 | Open right mouse button menu              | `m`             | Navigate using `↑` or `↓`                                   |
-| Pin active filter across resources        | `CTRL` + `p`    | Works also in the filter dialog                             |
+| Pin active filter across resources        | `CTRL` + `p`    | Also works in the filter dialog                             |
 | Quit the application                      | `CTRL` + `c`    | No confirmation dialog                                      |
 | Reverse selection                         | `CTRL` + ` `    | (`CTRL` + `SPACE`)                                          |
 | Select resource                           | ` `             | (`SPACE`)                                                   |
@@ -72,12 +72,56 @@ The following features are planned for future development:
 | Show command palette                      | `:`, `>`        | For example, entering `:q`↲ quits the application           |
 | Show events for the highlighted resource  | `e`             |                                                             |
 | Show filter / search input                | `/`             | Filter operators: and `&`, or `\|`, negation `!`, `(`, `)`  |
-| Show footer messages history pane         | `h`             | Also works left mouse button click on the footer            |
+| Show footer messages history pane         | `h`             | Also works with left mouse button click on the footer       |
 | Show logs for the pod or container        | `l`             | Press `p` to display previous logs                          |
-| Show namespaces selector                  | `←`             | To select `all` quickly press `←` again                     |
-| Show resources selector                   | `→`             | To select `pods` quickly press `→` again                    |
+| Show namespaces selector                  | `←`             | To select `all` rapidly press `←` again                     |
+| Show resources selector                   | `→`             | To select `pods` rapidly press `→` again                    |
 | Show YAML for the highlighted resource    | `y`             |                                                             |
-| Sort column                               | `ALT` + `[0-9]` | Also works `ALT` + `[underlined letter]`                    |
+| Sort column                               | `ALT` + `[0-9]` | Also works with `ALT` + `[underlined letter]`               |
+
+## Advanced Filtering
+
+The resources and port forwards views support advanced filtering with prefixes:
+
+- `ns:` - filter by namespace (e.g., `ns:kube-system`)
+- `n:` - filter by resource name (e.g., `n:nginx`)
+- `a:` - filter by annotations (e.g., `a:app.kubernetes.io/name=nginx`)
+- `l:` - filter by labels (e.g., `l:app=frontend`)
+
+Filters can be combined using logical operators: `&` (and), `|` (or), `!` (negation), and parentheses `()`.
+
+Example: `ns:default & (l:app=web | l:app=api)`
+
+> Note: `CTRL` + `p` will pin the active filter across resource changes
+
+## Logs View
+
+When viewing logs for a single container, you can fetch earlier log entries by pressing the `↑` (up arrow) key. This feature is only available when you are scrolled to the top of the currently displayed logs and there are additional log entries available before the first visible line.
+
+> Note: This functionality works only in single container logs view, not when viewing combined logs for all containers in a pod.
+
+## Text Selection and Editing
+
+When mouse support is enabled, you can:
+
+- **Select text** by clicking and dragging in YAML, logs, shell, and attach view
+- **Select whole words** by double-clicking
+- **Select whole lines** by triple-clicking
+- **Copy selected text** to clipboard using standard key bindings
+
+In edit mode, the following shortcuts are available:
+
+- `CTRL` + `c` - copy selected text
+- `CTRL` + `x` - cut selected text
+- `CTRL` + `v` - paste text from clipboard
+- `CTRL` + `a` - select all text
+- `CTRL` + `d` - delete current line
+- `CTRL` + `z` - undo
+- `CTRL` + `y` - redo
+- `ALT`  + `↑` - move current line up
+- `ALT`  + `↓` - move current line down
+
+> Note: These shortcuts currently cannot be changed in the `key_bindings` configuration section
 
 ## Configuration Files
 
@@ -130,16 +174,16 @@ key_bindings:
 
 #### Configuration Options
 
-- `logs.lines` – The number of log lines to retrieve from the Kubernetes API for selected container.
-- `logs.timestamps` – Indicates whether timestamps are enabled by default for logs; this setting can still be toggled while viewing the logs.
-- `mouse` – Indicates if mouse support should be enabled when the application starts. Mouse support can also be toggled while the app is running.
-- `theme` – The name of the currently selected theme. This should match a file in the `themes` directory (without the `.yaml` extension).
+- `logs.lines` - The number of log lines to retrieve from the Kubernetes API for the selected container.
+- `logs.timestamps` - Indicates whether timestamps are enabled by default for logs; this setting can still be toggled while viewing the logs.
+- `mouse` - Indicates if mouse support should be enabled when the application starts. Mouse support can also be toggled while the app is running.
+- `theme` - The name of the currently selected theme. This should match a file in the `themes` directory (without the `.yaml` extension).
 - `contexts` - _(Optional)_ A map of context names to their corresponding colors. Useful for highlighting important Kubernetes clusters with distinct header colors.
 - `aliases` - Command palette aliases.
-- `key_bindings` – Defines custom key bindings for various application actions.  
+- `key_bindings` - Defines custom key bindings for various application actions.  
   Example key bindings: `Ctrl+C`, `Ctrl+Alt+A`, `F7`, `Z`, `Left`, `Enter`.
 
-If `config.yaml` does not exist, the application will create it automatically with default values.
+> Note: If `config.yaml` does not exist, the application will create it automatically with default values.
 
 ### history.yaml
 

--- a/b4n/ui/views/resources/view.rs
+++ b/b4n/ui/views/resources/view.rs
@@ -446,7 +446,7 @@ impl ResourcesView {
 
         if !is_containers && !is_events {
             if self.table.list.table.data.is_creatable {
-                builder.add_menu_action(ActionItem::menu(7, "󰐕 create new", "create"));
+                builder.add_menu_action(ActionItem::menu(8, "󰐕 create new", "create"));
             }
             if is_highlighted {
                 builder.add_menu_action(ActionItem::menu(98, "󰑏 events", "show_events"));
@@ -460,14 +460,15 @@ impl ResourcesView {
         if is_highlighted {
             builder = builder
                 .with_menu_action(ActionItem::menu(1, " YAML", "show_yaml"))
-                .with_menu_action(ActionItem::menu(9, "󰆏 copy ␝name␝", "copy_name"));
+                .with_menu_action(ActionItem::menu(10, "󰆏 copy ␝name␝", "copy_name"));
 
             if is_containers || is_pods {
                 builder = builder
                     .with_menu_action(ActionItem::menu(2, " logs", "show_logs"))
                     .with_menu_action(ActionItem::menu(3, " logs ␝previous␝", "show_plogs"))
-                    .with_menu_action(ActionItem::menu(5, " shell", "open_shell"))
-                    .with_menu_action(ActionItem::menu(6, "󱘖 forward port", "port_forward"));
+                    .with_menu_action(ActionItem::menu(5, " attach", "attach"))
+                    .with_menu_action(ActionItem::menu(6, " shell", "open_shell"))
+                    .with_menu_action(ActionItem::menu(7, "󱘖 forward port", "port_forward"));
             }
 
             if self.table.kind_plural() == SECRETS {
@@ -475,7 +476,7 @@ impl ResourcesView {
             }
 
             if self.table.list.table.data.is_editable {
-                builder.add_menu_action(ActionItem::menu(8, " edit", "edit_yaml"));
+                builder.add_menu_action(ActionItem::menu(9, " edit", "edit_yaml"));
             }
         }
 

--- a/b4n/ui/views/shell/view.rs
+++ b/b4n/ui/views/shell/view.rs
@@ -58,7 +58,7 @@ impl ShellView {
         footer_tx: NotificationSink,
     ) -> Self {
         let mut header = ContentHeader::new(Rc::clone(&app_data), false);
-        header.set_title(if is_attach { " attach" } else { " shell" });
+        header.set_title(if is_attach { " attach" } else { " shell" });
         header.set_data(
             pod.namespace.clone(),
             PODS.into(),
@@ -109,7 +109,7 @@ impl ShellView {
         }
 
         let is_selected = self.selection.sorted().is_some();
-        let copy = if is_selected { "selected" } else { "all" };
+        let copy = if is_selected { "selection" } else { "all" };
         let detach = if self.is_attach { "󰕍 back" } else { " detach shell" };
         let builder = ActionsListBuilder::default()
             .with_menu_action(ActionItem::menu(1, &format!("󰆏 copy ␝{copy}␝"), "copy"))
@@ -359,8 +359,8 @@ impl View for ShellView {
             match key.code {
                 KeyCode::Char(input) => self.bridge.send(get_bytes(input, key.modifiers)),
                 KeyCode::Esc => self.bridge.send(vec![27]),
-                KeyCode::Backspace => self.bridge.send(vec![8]),
-                KeyCode::Enter => self.bridge.send(vec![b'\n']),
+                KeyCode::Backspace => self.bridge.send(vec![127]),
+                KeyCode::Enter => self.bridge.send(vec![b'\r']),
                 KeyCode::Left => self.bridge.send(vec![27, 91, 68]),
                 KeyCode::Right => self.bridge.send(vec![27, 91, 67]),
                 KeyCode::Up => self.bridge.send(vec![27, 91, 65]),


### PR DESCRIPTION
This PR fixes `Backspace` and `Enter` keys in attach view. It also adds some missing feature descriptions to the `README.md` file.