### PR TITLE
Fix previous resource selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 - fix `Backspace` and `Enter` keys in attach view
+- remember namespace for previously selected resource
 
 ## 0.4.6 - 2026-04-08
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -408,9 +408,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.59"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -856,9 +856,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "filedescriptor"
@@ -1124,6 +1124,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1270,12 +1276,12 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "indexmap"
-version = "2.13.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -1369,9 +1375,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.94"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -2557,9 +2563,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -3114,9 +3120,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.51.0"
+version = "1.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd1c4c0fc4a7ab90fc15ef6daaa3ec3b893f004f915f2392557ed23237820cd"
+checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
 dependencies = [
  "bytes",
  "libc",
@@ -3186,9 +3192,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.10+spec-1.1.0"
+version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82418ca169e235e6c399a84e395ab6debeb3bc90edc959bf0f48647c6a32d1b"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -3346,9 +3352,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tui-input"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79c1ee964298f136020f5f69e0e601f4d3a1f610a7baf1af9fcb96152e8a2c45"
+checksum = "932708e36347b2a0c4784b405c85b7a3d2f937f16660f37e2776b040fe680632"
 dependencies = [
  "ratatui",
  "unicode-width",
@@ -3356,9 +3362,9 @@ dependencies = [
 
 [[package]]
 name = "tui-term"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e676ed380f3015b1bbc07ce94c3fa7d7a450a4994b4ea2e1eca531e652bf6c4"
+checksum = "a338ded85dbe7f9ea2298321d126244f54e531e2b2006b97abdab8e47d6f3c88"
 dependencies = [
  "ratatui-core",
  "ratatui-widgets",
@@ -3559,9 +3565,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3572,9 +3578,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3582,9 +3588,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3595,9 +3601,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]

--- a/b4n-kube/core/resource_ref.rs
+++ b/b4n-kube/core/resource_ref.rs
@@ -1,5 +1,5 @@
 use k8s_openapi::jiff::Timestamp;
-use kube::api::ApiResource;
+use kube::{api::ApiResource, discovery::Scope};
 
 use super::{Kind, Namespace, PODS};
 
@@ -134,6 +134,16 @@ impl ResourceRef {
     /// Returns `true` if [`ResourceRef`] points to a filtered resource.
     pub fn is_filtered(&self) -> bool {
         self.filter.is_some()
+    }
+
+    /// Returns `true` if [`ResourceRef`] is equal to `other` considering specified `scope`.
+    pub fn is_equal(&self, other: &ResourceRef, scope: &Scope) -> bool {
+        self.kind == other.kind
+            && (*scope == Scope::Cluster || self.namespace == other.namespace)
+            && self.name == other.name
+            && self.filter == other.filter
+            && self.container == other.container
+            && self.all_containers == other.all_containers
     }
 }
 

--- a/b4n-kube/watcher/observer.rs
+++ b/b4n-kube/watcher/observer.rs
@@ -109,7 +109,8 @@ impl BgObserver {
         fallback_namespace: Option<Namespace>,
         stop_on_access_error: bool,
     ) -> Result<Scope, BgObserverError> {
-        if self.resource == new_resource {
+        let scope = discovery.as_ref().map(|(_, cap)| cap.scope.clone());
+        if self.resource.is_equal(&new_resource, &scope.unwrap_or(Scope::Namespaced)) {
             return Ok(self.scope.clone());
         }
 

--- a/b4n-list/scrollable_list.rs
+++ b/b4n-list/scrollable_list.rs
@@ -457,15 +457,6 @@ impl<T: Row + Filterable<Fc>, Fc: FilterContext> ScrollableList<T, Fc> {
         self.highlight_item_by(|i| i.data.is_equal(text)) || self.highlight_item_by(|i| i.data.starts_with(text))
     }
 
-    /// Highlights element on list by its name and group (if specified).
-    pub fn highlight_item_by_name_and_group(&mut self, name: &str, group: &str) -> bool {
-        if group.is_empty() {
-            self.highlight_item_by_name(name)
-        } else {
-            self.highlight_item_by(|i| i.data.name() == name && i.data.group() == group)
-        }
-    }
-
     /// Highlights element on list by its `uid`.
     pub fn highlight_item_by_uid(&mut self, uid: &str) -> bool {
         self.highlight_item_by(|i| i.data.uid() == uid)
@@ -485,6 +476,26 @@ impl<T: Row + Filterable<Fc>, Fc: FilterContext> ScrollableList<T, Fc> {
                 return true;
             }
 
+            self.items[highlighted].is_active = false;
+        }
+
+        self.items[index].is_active = true;
+        self.highlighted = Some(index);
+        true
+    }
+
+    /// Tries to highlight item finding it by closure.
+    pub fn highlight_item_by<F>(&mut self, f: F) -> bool
+    where
+        F: Fn(&Item<T, Fc>) -> bool,
+    {
+        let Some(index) = self.items.iter().position(f) else {
+            return false;
+        };
+
+        if let Some(highlighted) = self.highlighted
+            && highlighted < self.items.len()
+        {
             self.items[highlighted].is_active = false;
         }
 
@@ -519,26 +530,6 @@ impl<T: Row + Filterable<Fc>, Fc: FilterContext> ScrollableList<T, Fc> {
         }
 
         self.highlighted = None;
-    }
-
-    /// Tries to highlight item finding it by closure.
-    fn highlight_item_by<F>(&mut self, f: F) -> bool
-    where
-        F: Fn(&Item<T, Fc>) -> bool,
-    {
-        let Some(index) = self.items.iter().position(f) else {
-            return false;
-        };
-
-        if let Some(highlighted) = self.highlighted
-            && highlighted < self.items.len()
-        {
-            self.items[highlighted].is_active = false;
-        }
-
-        self.items[index].is_active = true;
-        self.highlighted = Some(index);
-        true
     }
 
     /// Adds `rows_to_move` to the currently highlighted item index.

--- a/b4n-list/scrollable_list.rs
+++ b/b4n-list/scrollable_list.rs
@@ -457,6 +457,15 @@ impl<T: Row + Filterable<Fc>, Fc: FilterContext> ScrollableList<T, Fc> {
         self.highlight_item_by(|i| i.data.is_equal(text)) || self.highlight_item_by(|i| i.data.starts_with(text))
     }
 
+    /// Highlights element on list by its name and group (if specified).
+    pub fn highlight_item_by_name_and_group(&mut self, name: &str, group: &str) -> bool {
+        if group.is_empty() {
+            self.highlight_item_by_name(name)
+        } else {
+            self.highlight_item_by(|i| i.data.name() == name && i.data.group() == group)
+        }
+    }
+
     /// Highlights element on list by its `uid`.
     pub fn highlight_item_by_uid(&mut self, uid: &str) -> bool {
         self.highlight_item_by(|i| i.data.uid() == uid)

--- a/b4n-tui/lib.rs
+++ b/b4n-tui/lib.rs
@@ -1,4 +1,4 @@
-pub use response::{ResponseEvent, Responsive, ScopeData};
+pub use response::{ResponseEvent, Responsive, ScopeData, ToSelectData};
 pub use tui::{MouseEvent, MouseEventKind, Tui, TuiEvent};
 
 pub mod table;

--- a/b4n-tui/response.rs
+++ b/b4n-tui/response.rs
@@ -36,6 +36,20 @@ impl ScopeData {
     }
 }
 
+/// Data for items to select (highlight) on the resource list.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ToSelectData {
+    Some(String, String),
+    None,
+}
+
+impl ToSelectData {
+    /// Creates new `Some` variant of `ToSelectData`.
+    pub fn new(name: impl Into<String>, namespace: Option<impl Into<String>>) -> Self {
+        Self::Some(name.into(), namespace.map(|i| i.into()).unwrap_or_default())
+    }
+}
+
 /// Terminal UI Response Event.
 #[derive(Debug, Clone, Default, PartialEq)]
 pub enum ResponseEvent {
@@ -49,19 +63,19 @@ pub enum ResponseEvent {
     ExitApplication,
 
     Change(String, String),
-    ChangeAndSelect(String, String, Option<String>),
-    ChangeAndSelectPrev(String, String, Option<String>),
+    ChangeAndSelect(String, String, ToSelectData),
+    ChangeAndSelectPrev(String, String, ToSelectData),
     ChangeKind(String),
-    ChangeKindAndSelect(String, Option<String>),
+    ChangeKindAndSelect(String, ToSelectData),
     ChangeNamespace(String),
     ChangeContext(String, Option<String>),
     ChangeTheme(String),
 
     ViewPreviousResource,
     ViewContainers(String, String),
-    ViewInvolved(String, String, Option<String>),
-    ViewScoped(String, Option<String>, Option<String>, ScopeData),
-    ViewScopedPrev(String, Option<String>, Option<String>, ScopeData),
+    ViewInvolved(String, String, ToSelectData),
+    ViewScoped(String, Option<String>, ToSelectData, ScopeData),
+    ViewScopedPrev(String, Option<String>, ToSelectData, ScopeData),
     ViewNamespaces,
     ListNamespaces,
 

--- a/b4n-tui/response.rs
+++ b/b4n-tui/response.rs
@@ -46,7 +46,7 @@ pub enum ToSelectData {
 impl ToSelectData {
     /// Creates new `Some` variant of `ToSelectData`.
     pub fn new(name: impl Into<String>, namespace: Option<impl Into<String>>) -> Self {
-        Self::Some(name.into(), namespace.map(|i| i.into()).unwrap_or_default())
+        Self::Some(name.into(), namespace.map(Into::into).unwrap_or_default())
     }
 }
 

--- a/b4n/core/app.rs
+++ b/b4n/core/app.rs
@@ -295,7 +295,7 @@ impl App {
                 self.data.borrow_mut().previous.clear();
             }
 
-            self.views_manager.handle_kind_change(to_select);
+            self.views_manager.handle_kind_change(to_select, namespace.as_option());
             self.views_manager.handle_namespace_change(namespace.clone());
             let resource = ResourceRef::new(kind.clone(), namespace.clone());
             let scope = self.worker.borrow_mut().restart(resource)?;
@@ -313,13 +313,13 @@ impl App {
             && (!kind.is_namespaces() || self.worker.borrow().namespaces.has_access())
         {
             let namespace = self.data.borrow().current.get_namespace();
-            let scope = self.worker.borrow_mut().restart_new_kind(kind.clone(), namespace)?;
-            if to_select.is_none() && kind.as_str() == NAMESPACES {
-                let to_select: Option<String> = Some(self.data.borrow().current.get_namespace().as_str().to_owned());
-                self.views_manager.handle_kind_change(to_select);
+            if kind.as_str() == NAMESPACES {
+                let to_select = to_select.or(Some(self.data.borrow().current.get_namespace().as_str().to_owned()));
+                self.views_manager.handle_kind_change(to_select, None);
             } else {
-                self.views_manager.handle_kind_change(to_select);
+                self.views_manager.handle_kind_change(to_select, namespace.as_option());
             }
+            let scope = self.worker.borrow_mut().restart_new_kind(kind.clone(), namespace)?;
             self.process_resources_change(Some(kind.into()), None, &scope);
             self.data.borrow_mut().previous.clear();
         }
@@ -390,7 +390,7 @@ impl App {
             }
 
             let is_all_namespaces = namespace.is_all();
-            self.views_manager.handle_kind_change(to_select);
+            self.views_manager.handle_kind_change(to_select, namespace.as_option());
             self.views_manager.cache_page_data();
             self.views_manager
                 .restore_page_data(Some(kind.as_str()), Some(namespace.as_str()), &scope.list, false);

--- a/b4n/core/app.rs
+++ b/b4n/core/app.rs
@@ -8,7 +8,7 @@ use b4n_tasks::commands::{
     Command, CommandResult, KubernetesClientError, KubernetesClientResult, ListKubeContextsCommand, ListThemesCommand,
 };
 use b4n_tui::widgets::Footer;
-use b4n_tui::{ResponseEvent, ScopeData, Tui, TuiEvent};
+use b4n_tui::{ResponseEvent, ScopeData, ToSelectData, Tui, TuiEvent};
 use kube::discovery::Scope;
 use std::cell::RefCell;
 use std::net::{IpAddr, SocketAddr};
@@ -207,14 +207,16 @@ impl App {
 
         match self.views_manager.process_event(event) {
             ResponseEvent::ExitApplication => return Ok(ResponseEvent::ExitApplication),
-            ResponseEvent::Change(kind, namespace) => self.change(kind.into(), namespace.into(), None, TrackFlow::Clear)?,
+            ResponseEvent::Change(kind, namespace) => {
+                self.change(kind.into(), namespace.into(), ToSelectData::None, TrackFlow::Clear)?
+            },
             ResponseEvent::ChangeAndSelect(kind, namespace, to_select) => {
                 self.change(kind.into(), namespace.into(), to_select, TrackFlow::Clear)?;
             },
             ResponseEvent::ChangeAndSelectPrev(kind, namespace, to_select) => {
                 self.change(kind.into(), namespace.into(), to_select, TrackFlow::Nothing)?;
             },
-            ResponseEvent::ChangeKind(kind) => self.change_kind(kind.into(), None)?,
+            ResponseEvent::ChangeKind(kind) => self.change_kind(kind.into(), ToSelectData::None)?,
             ResponseEvent::ChangeKindAndSelect(kind, to_select) => self.change_kind(kind.into(), to_select)?,
             ResponseEvent::ChangeNamespace(namespace) => self.change_namespace(namespace.into())?,
             ResponseEvent::ViewContainers(pod_name, pod_namespace) => self.view_containers(pod_name, pod_namespace.into())?,
@@ -281,7 +283,7 @@ impl App {
         &mut self,
         kind: Kind,
         namespace: Namespace,
-        to_select: Option<String>,
+        to_select: ToSelectData,
         track: TrackFlow,
     ) -> Result<(), BgWorkerError> {
         let kind = self.worker.borrow().ensure_kind_is_plural(kind);
@@ -295,7 +297,7 @@ impl App {
                 self.data.borrow_mut().previous.clear();
             }
 
-            self.views_manager.handle_kind_change(to_select, namespace.as_option());
+            self.views_manager.handle_kind_change(to_select);
             self.views_manager.handle_namespace_change(namespace.clone());
             let resource = ResourceRef::new(kind.clone(), namespace.clone());
             let scope = self.worker.borrow_mut().restart(resource)?;
@@ -307,17 +309,17 @@ impl App {
 
     /// Changes observed resources kind, optionally selects one of them.\
     /// **Note** that it selects current namespace if the resource kind is `namespaces`.
-    fn change_kind(&mut self, kind: Kind, to_select: Option<String>) -> Result<(), BgWorkerError> {
+    fn change_kind(&mut self, kind: Kind, to_select: ToSelectData) -> Result<(), BgWorkerError> {
         let kind = self.worker.borrow().ensure_kind_is_plural(kind);
         if (!self.data.borrow().current.is_kind_equal(&kind) || self.data.borrow().current.resource.filter.is_some())
             && (!kind.is_namespaces() || self.worker.borrow().namespaces.has_access())
         {
             let namespace = self.data.borrow().current.get_namespace();
             if kind.as_str() == NAMESPACES {
-                let to_select = to_select.or(Some(self.data.borrow().current.get_namespace().as_str().to_owned()));
-                self.views_manager.handle_kind_change(to_select, None);
+                let to_select = ToSelectData::Some(namespace.as_str().to_owned(), String::new());
+                self.views_manager.handle_kind_change(to_select);
             } else {
-                self.views_manager.handle_kind_change(to_select, namespace.as_option());
+                self.views_manager.handle_kind_change(to_select);
             }
             let scope = self.worker.borrow_mut().restart_new_kind(kind.clone(), namespace)?;
             self.process_resources_change(Some(kind.into()), None, &scope);
@@ -331,15 +333,13 @@ impl App {
     fn change_namespace(&mut self, namespace: Namespace) -> Result<(), BgWorkerError> {
         if !self.data.borrow().current.is_namespace_equal(&namespace) {
             if self.data.borrow().is_constrained() && !self.data.borrow().current.resource.kind.is_namespaces() {
-                let previous_kind = self.data.borrow().previous.last().map(|p| p.resource.kind.clone());
-                if let Some(kind) = previous_kind {
-                    let name = self
-                        .data
-                        .borrow()
-                        .previous
-                        .last()
-                        .and_then(|p| p.highlighted())
-                        .map(String::from);
+                let previous = self
+                    .data
+                    .borrow()
+                    .previous
+                    .last()
+                    .map(|p| (p.resource.kind.clone(), p.highlighted.clone()));
+                if let Some((kind, name)) = previous {
                     self.change(kind, namespace, name, TrackFlow::Clear)?;
                 }
             } else {
@@ -371,7 +371,7 @@ impl App {
     }
 
     /// Changes observed resource to the involved object.
-    fn view_involved(&mut self, kind: Kind, namespace: Namespace, to_select: Option<String>) -> Result<(), BgWorkerError> {
+    fn view_involved(&mut self, kind: Kind, namespace: Namespace, to_select: ToSelectData) -> Result<(), BgWorkerError> {
         self.change(kind, namespace, to_select, TrackFlow::Add)
     }
 
@@ -380,7 +380,7 @@ impl App {
         &mut self,
         kind: Kind,
         namespace: Namespace,
-        to_select: Option<String>,
+        to_select: ToSelectData,
         scope: ScopeData,
         track: TrackFlow,
     ) -> Result<(), BgWorkerError> {
@@ -390,7 +390,7 @@ impl App {
             }
 
             let is_all_namespaces = namespace.is_all();
-            self.views_manager.handle_kind_change(to_select, namespace.as_option());
+            self.views_manager.handle_kind_change(to_select);
             self.views_manager.cache_page_data();
             self.views_manager
                 .restore_page_data(Some(kind.as_str()), Some(namespace.as_str()), &scope.list, false);
@@ -406,7 +406,7 @@ impl App {
 
     /// Changes observed resources kind to `namespaces`.
     fn view_namespaces(&mut self) -> Result<(), BgWorkerError> {
-        self.change_kind(NAMESPACES.into(), None)
+        self.change_kind(NAMESPACES.into(), ToSelectData::None)
     }
 
     /// Runs command to list kube contexts from the current config.

--- a/b4n/core/app.rs
+++ b/b4n/core/app.rs
@@ -208,7 +208,7 @@ impl App {
         match self.views_manager.process_event(event) {
             ResponseEvent::ExitApplication => return Ok(ResponseEvent::ExitApplication),
             ResponseEvent::Change(kind, namespace) => {
-                self.change(kind.into(), namespace.into(), ToSelectData::None, TrackFlow::Clear)?
+                self.change(kind.into(), namespace.into(), ToSelectData::None, TrackFlow::Clear)?;
             },
             ResponseEvent::ChangeAndSelect(kind, namespace, to_select) => {
                 self.change(kind.into(), namespace.into(), to_select, TrackFlow::Clear)?;

--- a/b4n/core/data.rs
+++ b/b4n/core/data.rs
@@ -3,7 +3,7 @@ use b4n_common::NotificationSink;
 use b4n_config::keys::{KeyBindings, KeyCombination, KeyCommand};
 use b4n_config::{Config, History, themes::Theme};
 use b4n_kube::{CONTAINERS, InitData, Kind, Namespace, ResourceRef};
-use b4n_tui::TuiEvent;
+use b4n_tui::{ToSelectData, TuiEvent};
 use kube::discovery::Scope;
 use std::borrow::Cow;
 use std::{cell::RefCell, collections::HashSet, rc::Rc};
@@ -97,21 +97,13 @@ pub struct PreviousData {
     pub header: Scope,
     pub namespace: Namespace,
     pub resource: ResourceRef,
-    pub highlighted: Option<String>,
+    pub highlighted: ToSelectData,
     pub filter: Option<String>,
     pub sort_info: (usize, bool),
     pub offset: usize,
 }
 
 impl PreviousData {
-    /// Returns resource name that was previously highlighted on the list.
-    pub fn highlighted(&self) -> Option<&str> {
-        self.highlighted
-            .as_deref()
-            .or_else(|| self.resource.filter.as_ref()?.name.as_deref())
-            .or(self.resource.name.as_deref())
-    }
-
     /// Returns `kind` name for this previous data.
     pub fn get_kind_name(&self) -> String {
         self.resource.kind.name().to_owned()

--- a/b4n/core/managers/views.rs
+++ b/b4n/core/managers/views.rs
@@ -6,6 +6,7 @@ use b4n_tasks::commands::{
     CommandResult, DeleteResourcesOptions, GetNewResourceYamlError, GetNewResourceYamlResult, ResourceYamlError,
     ResourceYamlResult, SetNewResourceYamlError, SetResourceYamlError,
 };
+use b4n_tui::ToSelectData;
 use b4n_tui::widgets::Footer;
 use b4n_tui::{MouseEventKind, ResponseEvent, Responsive, TuiEvent, table::Table, table::ViewType};
 use kube::{config::NamedContext, discovery::Scope};
@@ -304,9 +305,9 @@ impl ViewsManager {
     }
 
     /// Handles kind change.
-    pub fn handle_kind_change(&mut self, resource_to_select: Option<String>, namespace: Option<&str>) {
+    pub fn handle_kind_change(&mut self, to_select: ToSelectData) {
         self.resources.clear_header_scope(true);
-        self.resources.set_next_highlight(resource_to_select, namespace);
+        self.resources.set_next_highlight(to_select);
         if let Some(view) = &mut self.view {
             view.handle_kind_change();
         }

--- a/b4n/core/managers/views.rs
+++ b/b4n/core/managers/views.rs
@@ -304,9 +304,9 @@ impl ViewsManager {
     }
 
     /// Handles kind change.
-    pub fn handle_kind_change(&mut self, resource_to_select: Option<String>) {
+    pub fn handle_kind_change(&mut self, resource_to_select: Option<String>, namespace: Option<&str>) {
         self.resources.clear_header_scope(true);
-        self.resources.set_next_highlight(resource_to_select);
+        self.resources.set_next_highlight(resource_to_select, namespace);
         if let Some(view) = &mut self.view {
             view.handle_kind_change();
         }

--- a/b4n/kube/resources/resources_list.rs
+++ b/b4n/kube/resources/resources_list.rs
@@ -102,7 +102,21 @@ impl ResourcesList {
     /// Returns `true` if the item with specified `name` and `group` was selected on the list.\
     /// **Note** that if `group` is empty it is omitted during check.
     pub fn highlight_item_by_name_and_group(&mut self, name: &str, group: &str) -> bool {
-        self.table.list.highlight_item_by_name_and_group(name, group)
+        if group.is_empty() {
+            self.table.list.highlight_item_by_name(name)
+        } else {
+            self.table
+                .list
+                .highlight_item_by(|i| i.data.name() == name && i.data.group() == group)
+        }
+    }
+
+    /// Gets highlighted item `name` and `group`.
+    pub fn get_highlighted_item_name_and_group(&self) -> Option<(&str, &str)> {
+        self.table
+            .list
+            .get_highlighted_item()
+            .map(|i| (i.data.name(), i.data.group()))
     }
 
     /// Gets highlighted resource.
@@ -191,7 +205,7 @@ impl ResourcesList {
     }
 
     fn update_kind(&mut self, init: InitData, is_from_cache: bool) {
-        let are_equal = self.data.resource == init.resource;
+        let are_equal = self.data.resource.is_equal(&init.resource, &init.scope);
         self.data = init;
         if !is_from_cache || !are_equal {
             self.table.update_header(ResourceItem::header(

--- a/b4n/kube/resources/resources_list.rs
+++ b/b4n/kube/resources/resources_list.rs
@@ -99,6 +99,12 @@ impl ResourcesList {
         self.data.resource.filter.is_some()
     }
 
+    /// Returns `true` if the item with specified `name` and `group` was selected on the list.\
+    /// **Note** that if `group` is empty it is omitted during check.
+    pub fn highlight_item_by_name_and_group(&mut self, name: &str, group: &str) -> bool {
+        self.table.list.highlight_item_by_name_and_group(name, group)
+    }
+
     /// Gets highlighted resource.
     pub fn get_highlighted_resource(&self) -> Option<&ResourceItem> {
         self.table.list.get_highlighted_item().map(|i| &i.data)

--- a/b4n/ui/views/resources/table.rs
+++ b/b4n/ui/views/resources/table.rs
@@ -121,8 +121,8 @@ impl ResourcesTable {
 
     /// Remembers resource name and namespace that will be highlighted for next background observer result.
     pub fn set_next_highlight(&mut self, to_select: ToSelectData) {
-        let highlight_item = match &to_select {
-            ToSelectData::Some(name, namespace) => Some((name.clone(), namespace.clone())),
+        let highlight_item = match to_select {
+            ToSelectData::Some(name, namespace) => Some((name, namespace)),
             ToSelectData::None => None,
         };
         self.next_refresh.highlight_item = highlight_item;

--- a/b4n/ui/views/resources/table.rs
+++ b/b4n/ui/views/resources/table.rs
@@ -5,6 +5,7 @@ use b4n_kube::{
     REPLICA_SETS, ResourceRef, ResourceRefFilter, ResourceTag, SECRETS, SERVICES, STATEFUL_SETS,
 };
 use b4n_list::Row;
+use b4n_tui::ToSelectData;
 use b4n_tui::{MouseEventKind, ResponseEvent, Responsive, ScopeData, TuiEvent, table::Table, table::ViewType};
 use crossterm::event::KeyModifiers;
 use delegate::delegate;
@@ -31,12 +32,10 @@ pub struct NextRefreshActions {
 impl NextRefreshActions {
     /// Creates new [`NextRefreshActions`] instance from the [`PreviousData`] object.
     pub fn from_previous(previous: &PreviousData) -> Self {
-        let highlight_item = previous.highlighted().map(|highlighted| {
-            (
-                highlighted.to_owned(),
-                previous.namespace.as_option().map(String::from).unwrap_or_default(),
-            )
-        });
+        let highlight_item = match &previous.highlighted {
+            ToSelectData::Some(name, namespace) => Some((name.clone(), namespace.clone())),
+            ToSelectData::None => None,
+        };
         NextRefreshActions {
             highlight_item,
             apply_filter: previous.filter.as_deref().map(String::from),
@@ -121,9 +120,12 @@ impl ResourcesTable {
     }
 
     /// Remembers resource name and namespace that will be highlighted for next background observer result.
-    pub fn set_next_highlight(&mut self, name: Option<String>, namespace: Option<&str>) {
-        let item = name.map(|name| (name, namespace.map(String::from).unwrap_or_default()));
-        self.next_refresh.highlight_item = item;
+    pub fn set_next_highlight(&mut self, to_select: ToSelectData) {
+        let highlight_item = match &to_select {
+            ToSelectData::Some(name, namespace) => Some((name.clone(), namespace.clone())),
+            ToSelectData::None => None,
+        };
+        self.next_refresh.highlight_item = highlight_item;
     }
 
     /// Remembers if header scope should be reset to default for next background observer result.
@@ -360,7 +362,7 @@ impl ResourcesTable {
                 return ResponseEvent::ViewInvolved(
                     involved.kind.clone().into(),
                     involved.namespace.clone().into(),
-                    Some(involved.name.clone()),
+                    ToSelectData::new(&involved.name, involved.namespace.as_option()),
                 );
             }
 
@@ -501,12 +503,17 @@ impl ResourcesTable {
             list: Scope::Cluster,
             filter: ResourceRefFilter::involved(resource.name.clone(), &resource.uid),
         };
-        ResponseEvent::ViewScoped(EVENTS.to_owned(), resource.namespace.clone(), None, scope)
+        ResponseEvent::ViewScoped(EVENTS.to_owned(), resource.namespace.clone(), ToSelectData::None, scope)
     }
 
     fn process_view_nodes(resource: &ResourceItem) -> ResponseEvent {
         let filter = ResourceRefFilter::node(resource.name.clone(), &resource.name);
-        ResponseEvent::ViewScoped(PODS.to_owned(), None, None, ScopeData::namespace_visible(filter))
+        ResponseEvent::ViewScoped(
+            PODS.to_owned(),
+            None,
+            ToSelectData::None,
+            ScopeData::namespace_visible(filter),
+        )
     }
 
     fn process_view_jobs(&self, resource: &ResourceItem) -> ResponseEvent {
@@ -515,7 +522,7 @@ impl ResourcesTable {
             list: Scope::Cluster,
             filter: ResourceRefFilter::job(resource.name.clone(), &resource.name),
         };
-        ResponseEvent::ViewScoped(PODS.to_owned(), resource.namespace.clone(), None, scope)
+        ResponseEvent::ViewScoped(PODS.to_owned(), resource.namespace.clone(), ToSelectData::None, scope)
     }
 
     fn process_view_selector(&self, resource: &ResourceItem, target: &str) -> ResponseEvent {
@@ -530,7 +537,7 @@ impl ResourcesTable {
             ResponseEvent::ViewScoped(
                 target.to_owned(),
                 resource.namespace.clone(),
-                None,
+                ToSelectData::None,
                 ScopeData::namespace_hidden(filter),
             )
         } else {

--- a/b4n/ui/views/resources/table.rs
+++ b/b4n/ui/views/resources/table.rs
@@ -21,7 +21,7 @@ use crate::ui::presentation::{ListHeader, ListViewer};
 /// Actions to perform on the next table refresh.
 #[derive(Default)]
 pub struct NextRefreshActions {
-    pub highlight_item: Option<String>,
+    pub highlight_item: Option<(String, String)>,
     pub apply_filter: Option<String>,
     pub apply_offset: Option<usize>,
     pub sort_info: Option<(usize, bool)>,
@@ -29,18 +29,16 @@ pub struct NextRefreshActions {
 }
 
 impl NextRefreshActions {
-    /// Creates new [`NextRefreshActions`] instance that will highlight `resource_name` on next refresh.
-    pub fn highlight(resource_name: Option<String>) -> Self {
-        NextRefreshActions {
-            highlight_item: resource_name,
-            ..Default::default()
-        }
-    }
-
     /// Creates new [`NextRefreshActions`] instance from the [`PreviousData`] object.
     pub fn from_previous(previous: &PreviousData) -> Self {
+        let highlight_item = previous.highlighted().map(|highlighted| {
+            (
+                highlighted.to_owned(),
+                previous.namespace.as_option().map(String::from).unwrap_or_default(),
+            )
+        });
         NextRefreshActions {
-            highlight_item: previous.highlighted().map(String::from),
+            highlight_item,
             apply_filter: previous.filter.as_deref().map(String::from),
             apply_offset: Some(previous.offset),
             sort_info: Some(previous.sort_info),
@@ -122,9 +120,10 @@ impl ResourcesTable {
         self.next_refresh = actions;
     }
 
-    /// Remembers resource name that will be highlighted for next background observer result.
-    pub fn set_next_highlight(&mut self, resource_to_select: Option<String>) {
-        self.next_refresh.highlight_item = resource_to_select;
+    /// Remembers resource name and namespace that will be highlighted for next background observer result.
+    pub fn set_next_highlight(&mut self, name: Option<String>, namespace: Option<&str>) {
+        let item = name.map(|name| (name, namespace.map(String::from).unwrap_or_default()));
+        self.next_refresh.highlight_item = item;
     }
 
     /// Remembers if header scope should be reset to default for next background observer result.
@@ -318,8 +317,8 @@ impl ResourcesTable {
     }
 
     fn process_initdone_result(&mut self) {
-        if let Some(name) = self.next_refresh.highlight_item.take() {
-            self.list.table.highlight_item_by_name(&name);
+        if let Some((name, group)) = self.next_refresh.highlight_item.take() {
+            self.list.table.highlight_item_by_name_and_group(&name, &group);
         } else if !self.list.table.is_anything_highlighted() {
             self.list.table.highlight_first_item();
         }

--- a/b4n/ui/views/resources/view.rs
+++ b/b4n/ui/views/resources/view.rs
@@ -546,9 +546,7 @@ impl ResourcesView {
 
     pub fn remember_current_resource(&mut self) {
         let highlighted = self.table.list.table.get_highlighted_item_name_and_group();
-        let highlighted = highlighted
-            .map(|(i, g)| ToSelectData::Some(i.to_owned(), g.to_owned()))
-            .unwrap_or(ToSelectData::None);
+        let highlighted = highlighted.map_or(ToSelectData::None, |(i, g)| ToSelectData::Some(i.to_owned(), g.to_owned()));
         let header = self.table.header.get_scope();
         let namespace = self.app_data.borrow().current.namespace.clone();
         let resource = self.app_data.borrow().current.resource.clone();

--- a/b4n/ui/views/resources/view.rs
+++ b/b4n/ui/views/resources/view.rs
@@ -60,7 +60,7 @@ impl ResourcesView {
         to self.table {
             pub fn set_resources_info(&mut self, context: String, namespace: Namespace, version: String, scope: Scope);
             pub fn set_next_refresh(&mut self, actions: NextRefreshActions);
-            pub fn set_next_highlight(&mut self, actions: Option<String>);
+            pub fn set_next_highlight(&mut self, name: Option<String>, namespace: Option<&str>);
             pub fn clear_header_scope(&mut self, clear_on_next: bool);
             pub fn deselect_all(&mut self);
             pub fn kind_plural(&self) -> &str;

--- a/b4n/ui/views/resources/view.rs
+++ b/b4n/ui/views/resources/view.rs
@@ -4,6 +4,7 @@ use b4n_kube::stats::SharedStatistics;
 use b4n_kube::{
     ALL_NAMESPACES, CONTAINERS, EVENTS, Kind, NAMESPACES, NODES, Namespace, ObserverResult, PODS, Port, ResourceRef, SECRETS,
 };
+use b4n_tui::ToSelectData;
 use b4n_tui::widgets::{ActionItem, ActionsList, ActionsListBuilder, Button, CheckBox, Dialog, Selector, ValidatorKind};
 use b4n_tui::{MouseEventKind, ResponseEvent, Responsive, ScopeData, TuiEvent, table::Table, table::ViewType};
 use delegate::delegate;
@@ -60,7 +61,7 @@ impl ResourcesView {
         to self.table {
             pub fn set_resources_info(&mut self, context: String, namespace: Namespace, version: String, scope: Scope);
             pub fn set_next_refresh(&mut self, actions: NextRefreshActions);
-            pub fn set_next_highlight(&mut self, name: Option<String>, namespace: Option<&str>);
+            pub fn set_next_highlight(&mut self, to_select: ToSelectData);
             pub fn clear_header_scope(&mut self, clear_on_next: bool);
             pub fn deselect_all(&mut self);
             pub fn kind_plural(&self) -> &str;
@@ -544,7 +545,10 @@ impl ResourcesView {
     }
 
     pub fn remember_current_resource(&mut self) {
-        let highlighted = self.table.list.table.get_highlighted_item_name().map(String::from);
+        let highlighted = self.table.list.table.get_highlighted_item_name_and_group();
+        let highlighted = highlighted
+            .map(|(i, g)| ToSelectData::Some(i.to_owned(), g.to_owned()))
+            .unwrap_or(ToSelectData::None);
         let header = self.table.header.get_scope();
         let namespace = self.app_data.borrow().current.namespace.clone();
         let resource = self.app_data.borrow().current.resource.clone();
@@ -564,7 +568,7 @@ impl ResourcesView {
         let data = &mut self.app_data.borrow_mut();
         if let Some(previous) = data.previous.pop() {
             self.table.set_next_refresh(NextRefreshActions::from_previous(&previous));
-            let to_select = previous.highlighted().map(String::from);
+            let to_select = previous.highlighted;
             if let Some(filter) = previous.resource.filter {
                 let scope = ScopeData {
                     list: previous.list,


### PR DESCRIPTION
This PR fixes `b4n` behaviour in selecting previous resource on the list if there are two resources with the same name in two different namespaces.