### PR TITLE
Update kube-rs to 4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## WIP
+
+### Features
+
+- use serde-saphyr instead of deprecated serde_yaml crate
+
+### Bug fixes
+
+- fix WINDOW column for PodMetrics kind
+
 ## 0.5.0 - 2026-06-19
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,6 +37,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "annotate-snippets"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f211a51805bc641f3ad5b7664c77d2547af685cc33b4cd8d31964027a46f13f1"
+dependencies = [
+ "anstyle",
+ "memchr",
+ "unicode-width",
+]
+
+[[package]]
 name = "ansi-to-tui"
 version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -130,6 +141,12 @@ dependencies = [
  "windows-sys 0.60.2",
  "x11rb",
 ]
+
+[[package]]
+name = "arraydeque"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
 name = "arrayvec"
@@ -248,7 +265,7 @@ dependencies = [
  "notify",
  "ratatui-core",
  "serde",
- "serde_yaml",
+ "serde-saphyr",
  "syntect",
  "thiserror 2.0.18",
  "tokio",
@@ -267,7 +284,7 @@ dependencies = [
  "k8s-openapi",
  "kube",
  "pin-project",
- "serde_yaml",
+ "serde-saphyr",
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
@@ -294,7 +311,7 @@ dependencies = [
  "k8s-openapi",
  "kube",
  "ratatui-core",
- "serde_yaml",
+ "serde-saphyr",
  "syntect",
  "thiserror 2.0.18",
  "tokio",
@@ -841,6 +858,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "encoding_rs_io"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cc3c5651fb62ab8aa3103998dade57efdd028544bd300516baa31840c252a83"
+dependencies = [
+ "encoding_rs",
+]
+
+[[package]]
 name = "enum-ordinalize"
 version = "4.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1135,9 +1170,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1167,6 +1204,16 @@ dependencies = [
  "futures-core",
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "granit-parser"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f50ba32164f9e098d5da618776a32afbb32270adcbe3d3d006107dae11e37c91"
+dependencies = [
+ "arraydeque",
+ "smallvec",
 ]
 
 [[package]]
@@ -1483,9 +1530,9 @@ dependencies = [
 
 [[package]]
 name = "k8s-openapi"
-version = "0.27.1"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b326f5219dd55872a72c1b6ddd1b830b8334996c667449c29391d657d78d5e"
+checksum = "d9c6922f6afe80418dd6019818af5d0d34584c371780ff09b9752370c25b4abb"
 dependencies = [
  "base64",
  "jiff",
@@ -1526,9 +1573,9 @@ dependencies = [
 
 [[package]]
 name = "kube"
-version = "3.1.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acc5a6a69da2975ed9925d56b5dcfc9cc739b66f37add06785b7c9f6d1e88741"
+checksum = "4bb9108095346a7096d11feeaff419c75dddcac1b2f59acb38d7bf3d13c3e146"
 dependencies = [
  "k8s-openapi",
  "kube-client",
@@ -1539,9 +1586,9 @@ dependencies = [
 
 [[package]]
 name = "kube-client"
-version = "3.1.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fcaf2d1f1a91e1805d4cd82e8333c022767ae8ffd65909bbef6802733a7dd40"
+checksum = "d0f628e05bc2264c21fe10d3d675117dc9b43ea3bf4fb07262a222679757537b"
 dependencies = [
  "base64",
  "bytes",
@@ -1562,8 +1609,8 @@ dependencies = [
  "rustls",
  "secrecy",
  "serde",
+ "serde-saphyr",
  "serde_json",
- "serde_yaml",
  "thiserror 2.0.18",
  "tokio",
  "tokio-tungstenite",
@@ -1575,9 +1622,9 @@ dependencies = [
 
 [[package]]
 name = "kube-core"
-version = "3.1.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f126d2db7a8b532ec1d839ece2a71e2485dc3bbca6cc3c3f929becaa810e719e"
+checksum = "c1b02f5933ba06140d58c7d6727f6c319f0962ec6a344aa5e21e475e891deaa8"
 dependencies = [
  "derive_more",
  "form_urlencoded",
@@ -1594,9 +1641,9 @@ dependencies = [
 
 [[package]]
 name = "kube-derive"
-version = "3.1.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6b9b97e121fce957f9cafc6da534abc4276983ab03190b76c09361e2df849fa"
+checksum = "fe171898707dadf1818ef94e81ef57f6beb7edf9ba87b9e814c045dad356c7aa"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1608,9 +1655,9 @@ dependencies = [
 
 [[package]]
 name = "kube-runtime"
-version = "3.1.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c072737075826ee74d3e615e80334e41e617ca3d14fb46ef7cdfda822d6f15f2"
+checksum = "99ddec66c540c7cf29a5b41fe4a657a53687f95c346e03bdf00585b70a1bab21"
 dependencies = [
  "ahash",
  "async-broadcast",
@@ -1800,6 +1847,12 @@ dependencies = [
  "libc",
  "memoffset",
 ]
+
+[[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "nom"
@@ -2772,6 +2825,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-saphyr"
+version = "0.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5897b4c3faadadd35fdb6689f015641f3bc481d5adaaac56231ea15aeb243db3"
+dependencies = [
+ "ahash",
+ "annotate-snippets",
+ "base64",
+ "encoding_rs_io",
+ "getrandom 0.3.4",
+ "granit-parser",
+ "nohash-hasher",
+ "num-traits",
+ "serde",
+ "smallvec",
+ "zmij",
+]
+
+[[package]]
 name = "serde-value"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2823,19 +2895,6 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
-]
-
-[[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
-dependencies = [
- "indexmap",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
 ]
 
 [[package]]
@@ -3276,9 +3335,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
 dependencies = [
  "futures-util",
  "log",
@@ -3494,9 +3553,9 @@ dependencies = [
 
 [[package]]
 name = "tungstenite"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
 dependencies = [
  "bytes",
  "data-encoding",
@@ -3506,7 +3565,6 @@ dependencies = [
  "rand 0.9.4",
  "sha1 0.10.6",
  "thiserror 2.0.18",
- "utf-8",
 ]
 
 [[package]]
@@ -3557,22 +3615,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
-
-[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
-
-[[package]]
-name = "utf-8"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 [workspace.package]
 version = "0.5.0"
 edition = "2024"
-rust-version = "1.88"
+rust-version = "1.95"
 license = "MIT"
 
 [workspace.dependencies]
@@ -33,8 +33,8 @@ delegate = { version = "0.13" }
 futures = { version = "0.3" }
 http = { version = "1" }
 jsonpath-rust = { version = "1" }
-k8s-openapi = { version = "0.27", features = ["latest"] }
-kube = { version = "3.1", features = ["client", "derive", "runtime", "ws"] }
+k8s-openapi = { version = "0.28", features = ["latest"] }
+kube = { version = "4.0", features = ["client", "derive", "runtime", "ws"] }
 notify = { version = "8.0" }
 pin-project = { version = "1.1" }
 ratatui = { version = "0.30", features = ["serde"] }
@@ -42,7 +42,7 @@ ratatui-core = { version = "0.1", features = ["serde"] }
 ratatui-crossterm = { version = "0.1" }
 ratatui-widgets = { version = "0.3" }
 serde = { version = "1.0", features = ["derive"] }
-serde_yaml = { version = "0.9" }
+serde-saphyr = { version = "0.0.27" }
 sha1 = { version = "0.11" }
 syntect = { version = "5.3" }
 textwrap = { version = "0.16" }

--- a/assets/themes/light-fixed.yaml
+++ b/assets/themes/light-fixed.yaml
@@ -161,6 +161,6 @@ colors:
   shell:
     select: select_light
   syntax:
-    describe: *yaml 
+    describe: *yaml
     yaml: *yaml
     logs: *logs

--- a/b4n-config/Cargo.toml
+++ b/b4n-config/Cargo.toml
@@ -15,7 +15,7 @@ crossterm = { workspace = true }
 notify = { workspace = true }
 ratatui-core = { workspace = true }
 serde = { workspace = true }
-serde_yaml = { workspace = true }
+serde-saphyr = { workspace = true }
 syntect = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }

--- a/b4n-config/config.rs
+++ b/b4n-config/config.rs
@@ -24,9 +24,13 @@ pub enum ConfigError {
     #[error("cannot read/write configuration file")]
     IoError(#[from] std::io::Error),
 
-    /// Cannot serialize/deserialize configuration.
-    #[error("cannot serialize/deserialize configuration")]
-    SerializationError(#[from] serde_yaml::Error),
+    /// Cannot serialize configuration.
+    #[error("cannot serialize configuration")]
+    SerializationError(#[from] serde_saphyr::ser::Error),
+
+    /// Cannot deserialize configuration.
+    #[error("cannot deserialize configuration")]
+    DeserializationError(#[from] serde_saphyr::Error),
 }
 
 /// Kubernetes logs configuration.
@@ -170,11 +174,11 @@ impl Persistable<Config> for Config {
         let mut config_str = String::new();
         file.read_to_string(&mut config_str).await?;
 
-        Ok(serde_yaml::from_str::<Config>(&config_str)?)
+        Ok(serde_saphyr::from_str::<Config>(&config_str)?)
     }
 
     async fn save(&self, path: &Path) -> Result<(), ConfigError> {
-        let config_str = serde_yaml::to_string(self)?;
+        let config_str = serde_saphyr::to_string(self)?;
 
         let mut file = File::create(path).await?;
         file.write_all(config_str.as_bytes()).await?;
@@ -188,9 +192,9 @@ async fn load_or_create_default<T: Persistable<T> + Default>(path: &Path) -> (T,
     let configuration = T::load(path).await;
     match configuration {
         Ok(configuration) => (configuration, None),
-        Err(ConfigError::SerializationError(error)) => {
+        Err(ConfigError::DeserializationError(error)) => {
             tracing::error!("Cannot deserialize config: {}", error);
-            (T::default(), Some(ConfigError::SerializationError(error)))
+            (T::default(), Some(ConfigError::DeserializationError(error)))
         },
         Err(error) => {
             tracing::error!("Cannot load config: {}", error);

--- a/b4n-config/history.rs
+++ b/b4n-config/history.rs
@@ -281,11 +281,11 @@ impl Persistable<History> for History {
         let mut history_str = String::new();
         file.read_to_string(&mut history_str).await?;
 
-        Ok(serde_yaml::from_str::<History>(&history_str)?)
+        Ok(serde_saphyr::from_str::<History>(&history_str)?)
     }
 
     async fn save(&self, path: &Path) -> Result<(), ConfigError> {
-        let history_str = serde_yaml::to_string(self)?;
+        let history_str = serde_saphyr::to_string(self)?;
 
         let mut file = File::create(path).await?;
         file.write_all(history_str.as_bytes()).await?;

--- a/b4n-config/keys/binding.tests.rs
+++ b/b4n-config/keys/binding.tests.rs
@@ -5,8 +5,8 @@ use super::*;
 #[test]
 fn serialize_bindings_test() {
     let bindings = KeyBindings::default();
-    let serialized = serde_yaml::to_string(&bindings).unwrap();
-    let deserialized: KeyBindings = serde_yaml::from_str(&serialized).unwrap();
+    let serialized = serde_saphyr::to_string(&bindings).unwrap();
+    let deserialized: KeyBindings = serde_saphyr::from_str(&serialized).unwrap();
 
     assert_eq!(bindings, deserialized);
 }
@@ -61,7 +61,7 @@ fn command_from_str_test() {
 
 #[test]
 fn serialize_command_test() {
-    let key = serde_yaml::to_string(&KeyCommand::ApplicationExit).unwrap();
+    let key = serde_saphyr::to_string(&KeyCommand::ApplicationExit).unwrap();
     assert_eq!("app.exit", key.trim());
 }
 
@@ -69,6 +69,6 @@ fn serialize_command_test() {
 fn deserialize_command_test() {
     assert_eq!(
         KeyCommand::CommandPaletteOpen,
-        serde_yaml::from_str("command-palette.open").unwrap()
+        serde_saphyr::from_str("command-palette.open").unwrap()
     );
 }

--- a/b4n-config/keys/combination.tests.rs
+++ b/b4n-config/keys/combination.tests.rs
@@ -53,49 +53,49 @@ fn from_str_test() {
 
 #[test]
 fn serialize_test() {
-    let key = serde_yaml::to_string(&KeyCombination::new(KeyCode::Null, KeyModifiers::NONE)).unwrap();
-    assert_eq!("'Null'", key.trim());
+    let key = serde_saphyr::to_string(&KeyCombination::new(KeyCode::Null, KeyModifiers::NONE)).unwrap();
+    assert_eq!("\"Null\"", key.trim());
 
-    let key = serde_yaml::to_string(&KeyCombination::new(KeyCode::Char('a'), KeyModifiers::NONE)).unwrap();
+    let key = serde_saphyr::to_string(&KeyCombination::new(KeyCode::Char('a'), KeyModifiers::NONE)).unwrap();
     assert_eq!("A", key.trim());
 
-    let key = serde_yaml::to_string(&KeyCombination::new(KeyCode::F(5), KeyModifiers::NONE)).unwrap();
+    let key = serde_saphyr::to_string(&KeyCombination::new(KeyCode::F(5), KeyModifiers::NONE)).unwrap();
     assert_eq!("F5", key.trim());
 
-    let key = serde_yaml::to_string(&KeyCombination::new(KeyCode::Char('A'), KeyModifiers::SHIFT)).unwrap();
+    let key = serde_saphyr::to_string(&KeyCombination::new(KeyCode::Char('A'), KeyModifiers::SHIFT)).unwrap();
     assert_eq!("Shift+A", key.trim());
 
-    let key = serde_yaml::to_string(&KeyCombination::new(
+    let key = serde_saphyr::to_string(&KeyCombination::new(
         KeyCode::Char('z'),
         KeyModifiers::CONTROL | KeyModifiers::SHIFT | KeyModifiers::ALT,
     ))
     .unwrap();
     assert_eq!("Shift+Ctrl+Alt+Z", key.trim());
 
-    let key = serde_yaml::to_string(&KeyCombination::new(KeyCode::Backspace, KeyModifiers::SHIFT)).unwrap();
+    let key = serde_saphyr::to_string(&KeyCombination::new(KeyCode::Backspace, KeyModifiers::SHIFT)).unwrap();
     assert_eq!("Shift+Backspace", key.trim());
 }
 
 #[test]
 fn deserialize_test() {
-    let key = serde_yaml::from_str("'Null'").unwrap();
+    let key = serde_saphyr::from_str("\"Null\"").unwrap();
     assert_eq!(KeyCombination::new(KeyCode::Null, KeyModifiers::NONE), key);
 
-    let key = serde_yaml::from_str("Ctrl+A").unwrap();
+    let key = serde_saphyr::from_str("Ctrl+A").unwrap();
     assert_eq!(KeyCombination::new(KeyCode::Char('A'), KeyModifiers::CONTROL), key);
 
-    let key = serde_yaml::from_str("shift+Ctrl+x").unwrap();
+    let key = serde_saphyr::from_str("shift+Ctrl+x").unwrap();
     assert_eq!(
         KeyCombination::new(KeyCode::Char('X'), KeyModifiers::CONTROL | KeyModifiers::SHIFT),
         key
     );
 
-    let key = serde_yaml::from_str("LEFT").unwrap();
+    let key = serde_saphyr::from_str("LEFT").unwrap();
     assert_eq!(KeyCombination::new(KeyCode::Left, KeyModifiers::NONE), key);
 
-    let key = serde_yaml::from_str("F7").unwrap();
+    let key = serde_saphyr::from_str("F7").unwrap();
     assert_eq!(KeyCombination::new(KeyCode::F(7), KeyModifiers::NONE), key);
 
-    let key = serde_yaml::from_str("Shift+F12").unwrap();
+    let key = serde_saphyr::from_str("Shift+F12").unwrap();
     assert_eq!(KeyCombination::new(KeyCode::F(12), KeyModifiers::SHIFT), key);
 }

--- a/b4n-config/themes/theme.rs
+++ b/b4n-config/themes/theme.rs
@@ -1,7 +1,8 @@
 use ratatui_core::style::Color;
-use serde::{Deserialize, Serialize};
-use serde_yaml::Value;
-use std::collections::HashMap;
+use serde::de::{self, Visitor};
+use serde::{Deserialize, Deserializer, Serialize};
+use std::collections::BTreeMap;
+use std::fmt;
 use std::path::{Path, PathBuf};
 use tokio::fs::File;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -354,13 +355,6 @@ pub struct ThemeColors {
     pub syntax: SyntaxColors,
 }
 
-#[derive(Default, Serialize, Deserialize)]
-struct ColorsDefinition {
-    #[serde(skip_serializing)]
-    pub palette: Option<HashMap<String, String>>,
-    pub colors: Value,
-}
-
 /// Theme used in the application.
 #[derive(Serialize, Deserialize, Clone)]
 pub struct Theme {
@@ -442,19 +436,19 @@ impl Persistable<Theme> for Theme {
         let mut theme_str = String::new();
         file.read_to_string(&mut theme_str).await?;
 
-        let mut definitions = serde_yaml::from_str::<ColorsDefinition>(&theme_str)?;
+        let mut definitions = serde_saphyr::from_str::<ColorsDefinition>(&theme_str)?;
         if let Some(palette) = &definitions.palette
             && !palette.is_empty()
         {
             update_colors(&mut definitions.colors, palette);
-            theme_str = serde_yaml::to_string(&definitions)?;
+            theme_str = serde_saphyr::to_string(&definitions)?;
         }
 
-        Ok(serde_yaml::from_str::<Theme>(&theme_str)?)
+        Ok(serde_saphyr::from_str::<Theme>(&theme_str)?)
     }
 
     async fn save(&self, path: &Path) -> Result<(), ConfigError> {
-        let history_str = serde_yaml::to_string(self)?;
+        let history_str = serde_saphyr::to_string(self)?;
 
         let mut file = File::create(path).await?;
         file.write_all(history_str.as_bytes()).await?;
@@ -475,29 +469,80 @@ fn get_theme_item(scope: &str, colors: TextColors) -> syntect::highlighting::The
     }
 }
 
-fn update_colors(colors: &mut Value, palette: &HashMap<String, String>) {
-    let mut stack = vec![colors];
+#[derive(Default, Serialize, Deserialize)]
+struct ColorsDefinition {
+    #[serde(skip_serializing)]
+    pub palette: Option<BTreeMap<String, String>>,
+    pub colors: BTreeMap<String, ColorValue>,
+}
 
-    while let Some(current) = stack.pop() {
-        match current {
-            Value::Mapping(map) => {
-                for v in map.values_mut() {
-                    stack.push(v);
+#[derive(Debug, Serialize)]
+enum ColorValue {
+    String(String),
+    Mapping(BTreeMap<String, ColorValue>),
+    Sequence(Vec<String>),
+}
+
+impl Default for ColorValue {
+    fn default() -> Self {
+        Self::String(String::new())
+    }
+}
+
+impl<'de> Deserialize<'de> for ColorValue {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct ColorsVisitor;
+
+        impl<'de> Visitor<'de> for ColorsVisitor {
+            type Value = ColorValue;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("a string, map, or sequence")
+            }
+
+            fn visit_str<E: de::Error>(self, v: &str) -> Result<ColorValue, E> {
+                Ok(ColorValue::String(v.to_owned()))
+            }
+
+            fn visit_map<A: de::MapAccess<'de>>(self, mut map: A) -> Result<ColorValue, A::Error> {
+                let mut result = BTreeMap::new();
+                while let Some((k, v)) = map.next_entry::<String, ColorValue>()? {
+                    result.insert(k, v);
+                }
+                Ok(ColorValue::Mapping(result))
+            }
+
+            fn visit_seq<A: de::SeqAccess<'de>>(self, mut seq: A) -> Result<ColorValue, A::Error> {
+                let mut result = Vec::new();
+                while let Some(v) = seq.next_element::<String>()? {
+                    result.push(v);
+                }
+                Ok(ColorValue::Sequence(result))
+            }
+        }
+
+        deserializer.deserialize_any(ColorsVisitor)
+    }
+}
+
+fn update_colors(colors: &mut BTreeMap<String, ColorValue>, palette: &BTreeMap<String, String>) {
+    fn resolve(color: &str, palette: &BTreeMap<String, String>) -> String {
+        color
+            .split(':')
+            .map(|c| palette.get(c).map(|s| s.as_str()).unwrap_or(c))
+            .collect::<Vec<&str>>()
+            .join(":")
+    }
+
+    for color in colors.values_mut() {
+        match color {
+            ColorValue::String(s) => *s = resolve(s, palette),
+            ColorValue::Mapping(map) => update_colors(map, palette),
+            ColorValue::Sequence(seq) => {
+                for v in seq {
+                    *v = resolve(v, palette);
                 }
             },
-            Value::Sequence(sequence) => {
-                for v in sequence {
-                    stack.push(v);
-                }
-            },
-            Value::String(string) => {
-                *string = string
-                    .split(':')
-                    .map(|c| if palette.contains_key(c) { &palette[c] } else { c })
-                    .collect::<Vec<&str>>()
-                    .join(":");
-            },
-            _ => (),
         }
     }
 }

--- a/b4n-config/themes/theme.rs
+++ b/b4n-config/themes/theme.rs
@@ -1,6 +1,7 @@
 use ratatui_core::style::Color;
 use serde::de::{self, Visitor};
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::ser::{SerializeMap, SerializeSeq};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::collections::BTreeMap;
 use std::fmt;
 use std::path::{Path, PathBuf};
@@ -476,7 +477,7 @@ struct ColorsDefinition {
     pub colors: BTreeMap<String, ColorValue>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug)]
 enum ColorValue {
     String(String),
     Mapping(BTreeMap<String, ColorValue>),
@@ -486,6 +487,28 @@ enum ColorValue {
 impl Default for ColorValue {
     fn default() -> Self {
         Self::String(String::new())
+    }
+}
+
+impl Serialize for ColorValue {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match self {
+            ColorValue::String(s) => serializer.serialize_str(s),
+            ColorValue::Mapping(map) => {
+                let mut m = serializer.serialize_map(Some(map.len()))?;
+                for (k, v) in map {
+                    m.serialize_entry(k, v)?;
+                }
+                m.end()
+            },
+            ColorValue::Sequence(seq) => {
+                let mut s = serializer.serialize_seq(Some(seq.len()))?;
+                for item in seq {
+                    s.serialize_element(item)?;
+                }
+                s.end()
+            },
+        }
     }
 }
 

--- a/b4n-kube/Cargo.toml
+++ b/b4n-kube/Cargo.toml
@@ -16,7 +16,7 @@ futures = { workspace = true }
 k8s-openapi = { workspace = true }
 kube = { workspace = true }
 pin-project = { workspace = true }
-serde_yaml = { workspace = true }
+serde-saphyr = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }

--- a/b4n-kube/utils.rs
+++ b/b4n-kube/utils.rs
@@ -8,9 +8,9 @@ use kube::discovery::ApiCapabilities;
 use crate::{DiscoveryList, Kind, ResourceTag};
 
 /// Serializes kubernetes resource to YAML.
-pub fn serialize_resource(resource: &mut DynamicObject) -> Result<String, serde_yaml::Error> {
+pub fn serialize_resource(resource: &mut DynamicObject) -> Result<String, serde_saphyr::ser::Error> {
     resource.managed_fields_mut().clear();
-    let mut yaml = serde_yaml::to_string(resource)?;
+    let mut yaml = serde_saphyr::to_string(resource)?;
 
     if let Some(index) = yaml.find("\n  managedFields: []\n") {
         yaml.replace_range(index + 1..index + 21, "");
@@ -139,7 +139,7 @@ pub fn can_patch_status(cap: &ApiCapabilities) -> bool {
 pub fn deserialize_kind(yaml: &[String]) -> Option<String> {
     for line in yaml {
         if line.starts_with("kind:") {
-            let v = serde_yaml::from_str::<Value>(line).ok()?;
+            let v = serde_saphyr::from_str::<Value>(line).ok()?;
             return v.get("kind").and_then(|k| k.as_str()).map(String::from);
         }
     }

--- a/b4n-kube/watcher/result.rs
+++ b/b4n-kube/watcher/result.rs
@@ -29,7 +29,7 @@ impl<T> ObserverResult<T> {
 }
 
 /// Data that is returned when [`BgObserver`] starts watching resource.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct InitData {
     pub uuid: String,
     pub resource: ResourceRef,

--- a/b4n-tasks/Cargo.toml
+++ b/b4n-tasks/Cargo.toml
@@ -16,7 +16,7 @@ http = { workspace = true }
 k8s-openapi = { workspace = true }
 kube = { workspace = true }
 ratatui-core = { workspace = true }
-serde_yaml = { workspace = true }
+serde-saphyr = { workspace = true }
 syntect = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }

--- a/b4n-tasks/commands/get_new_yaml.rs
+++ b/b4n-tasks/commands/get_new_yaml.rs
@@ -17,7 +17,7 @@ pub enum GetNewResourceYamlError {
 
     /// Failed to serialize YAML schemas.
     #[error("failed to serialize YAML schemas")]
-    YamlSerializationError(#[from] serde_yaml::Error),
+    YamlSerializationError(#[from] serde_saphyr::ser::Error),
 
     /// Failed to serialize YAML schemas.
     #[error("failed to serialize YAML schemas")]
@@ -81,7 +81,7 @@ impl GetNewResourceYamlCommand {
         let result = async {
             let (root, schema) = get_resource_schema(client, res).await?;
             let yaml_val = build_resource(res, cap, self.namespace.clone(), &root, &schema, self.required_only);
-            let yaml_str = serde_yaml::to_string(&yaml_val)?;
+            let yaml_str = serde_saphyr::to_string(&yaml_val)?;
             self.style_yaml(yaml_str, res, cap).await
         }
         .await;

--- a/b4n-tasks/commands/set_new_yaml.rs
+++ b/b4n-tasks/commands/set_new_yaml.rs
@@ -24,7 +24,7 @@ pub enum SetNewResourceYamlError {
 
     /// Failed to deserialize YAML into resource.
     #[error("failed to deserialize YAML: {0}")]
-    SerializationError(#[from] serde_yaml::Error),
+    SerializationError(#[from] serde_saphyr::Error),
 
     /// Specified group, version and kind not found.
     #[error("specified group, version and kind not found")]
@@ -67,7 +67,7 @@ impl SetNewResourceYamlCommand {
     }
 
     async fn create_resource(self, client: Client) -> Result<String, SetNewResourceYamlError> {
-        let mut resource = serde_yaml::from_str::<DynamicObject>(&self.yaml)?;
+        let mut resource = serde_saphyr::from_str::<DynamicObject>(&self.yaml)?;
         if self.options.encode
             && let Some(data) = resource.data.get_mut("data")
         {

--- a/b4n-tasks/commands/set_yaml.rs
+++ b/b4n-tasks/commands/set_yaml.rs
@@ -19,7 +19,7 @@ pub enum SetResourceYamlError {
     SerializationError {
         resource: String,
         #[source]
-        source: serde_yaml::Error,
+        source: serde_saphyr::Error,
     },
 
     /// Failed to patch or apply YAML to the Kubernetes resource.
@@ -129,7 +129,7 @@ impl SetResourceYamlCommand {
         update_status: bool,
         ignore_version: bool,
     ) -> Result<String, SetResourceYamlError> {
-        let mut resource = serde_yaml::from_str::<k8s_openapi::serde_json::Value>(&self.yaml).map_err(|e| {
+        let mut resource = serde_saphyr::from_str::<k8s_openapi::serde_json::Value>(&self.yaml).map_err(|e| {
             SetResourceYamlError::SerializationError {
                 resource: self.name.clone(),
                 source: e,

--- a/b4n-tasks/highlighter.rs
+++ b/b4n-tasks/highlighter.rs
@@ -143,7 +143,7 @@ fn convert_style(style: syntect::highlighting::Style) -> Style {
 pub enum HighlightResourceError {
     /// Cannot serialize resource's YAML.
     #[error("cannot serialize resource's YAML")]
-    SerializationError(#[from] serde_yaml::Error),
+    SerializationError(#[from] serde_saphyr::ser::Error),
 
     /// Cannot send syntax highlight request to the highlighter thread.
     #[error("cannot send syntax highlight request")]

--- a/b4n/kube/resources/data/node_metrics.rs
+++ b/b4n/kube/resources/data/node_metrics.rs
@@ -34,4 +34,5 @@ pub fn header() -> Header {
         ])),
         Rc::new([' ', 'N', 'C', 'M', 'W', 'A']),
     )
+    .with_age_column(false)
 }

--- a/b4n/kube/resources/data/pod_metrics.rs
+++ b/b4n/kube/resources/data/pod_metrics.rs
@@ -43,4 +43,5 @@ pub fn header() -> Header {
         ])),
         Rc::new([' ', 'N', 'C', 'M', 'W', 'A']),
     )
+    .with_age_column(false)
 }

--- a/b4n/kube/resources/resource.rs
+++ b/b4n/kube/resources/resource.rs
@@ -19,6 +19,7 @@ use crate::ui::widgets::table::Cell;
 mod resource_tests;
 
 /// Represents involved object of the resource.
+#[derive(Debug)]
 pub struct InvolvedObject {
     pub kind: Kind,
     pub namespace: Namespace,
@@ -39,7 +40,7 @@ pub enum ColumnsLayout {
 }
 
 /// Represents kubernetes resource of any kind.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct ResourceItem {
     pub uid: String,
     pub name: String,

--- a/b4n/kube/resources/resource_data.rs
+++ b/b4n/kube/resources/resource_data.rs
@@ -4,7 +4,7 @@ use b4n_kube::ResourceTag;
 use crate::ui::widgets::table::Cell;
 
 /// Extra data for the kubernetes resource.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct ResourceData {
     pub is_completed: bool,
     pub is_ready: bool,

--- a/b4n/kube/resources/resources_list.rs
+++ b/b4n/kube/resources/resources_list.rs
@@ -111,7 +111,7 @@ impl ResourcesList {
 
     /// Updates [`ResourcesList`] with new data from [`PortForwardItem`] collection.
     pub fn update_port_forwards(&mut self, forwards: &[&ResourceRef]) {
-        if self.data.kind_plural == PODS {
+        if self.data.kind_plural == PODS && self.data.group.is_empty() {
             for item in self.table.list.full_iter_mut() {
                 let has_port_forward = forwards
                     .iter()

--- a/b4n/ui/widgets/table/cell.rs
+++ b/b4n/ui/widgets/table/cell.rs
@@ -5,7 +5,7 @@ use k8s_openapi::serde_json::{Value, from_value};
 use std::borrow::Cow;
 
 /// Table cell.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct Cell {
     text: Option<String>,
     sort_text: Option<String>,


### PR DESCRIPTION
This PR updates kube-rs crate to version 4.0.0, this update also forces to switch form serde_yaml carte (that is for some time deprecated) to serde-saphyr (used by kube-rs) crate.