### PR TITLE
Fix command palette highlights wrong item on the list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## WIP
+
+### Bug fixes
+
+- fix command palette highlights wrong item on the list
+
 ## 0.5.1 - 2026-07-01
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,6 +254,7 @@ dependencies = [
  "tracing-appender",
  "tracing-error",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]
@@ -272,7 +273,6 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
- "uuid",
 ]
 
 [[package]]
@@ -291,7 +291,6 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
- "uuid",
 ]
 
 [[package]]
@@ -319,7 +318,6 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
- "uuid",
 ]
 
 [[package]]

--- a/b4n-common/Cargo.toml
+++ b/b4n-common/Cargo.toml
@@ -19,3 +19,4 @@ tracing = { workspace = true }
 tracing-appender = { workspace = true }
 tracing-error = { workspace = true }
 tracing-subscriber = { workspace = true }
+uuid = { workspace = true }

--- a/b4n-common/utils.rs
+++ b/b4n-common/utils.rs
@@ -1,4 +1,5 @@
 use sha1::{Digest, Sha1};
+use uuid::Uuid;
 
 #[cfg(test)]
 #[path = "./utils.tests.rs"]
@@ -156,4 +157,12 @@ pub fn sanitize_and_split(input: &str) -> Vec<String> {
     lines.push(current);
 
     lines
+}
+
+/// Creates random `Uuid` as `String`.
+pub fn random_uuid() -> String {
+    Uuid::new_v4()
+        .hyphenated()
+        .encode_lower(&mut Uuid::encode_buffer())
+        .to_owned()
 }

--- a/b4n-config/Cargo.toml
+++ b/b4n-config/Cargo.toml
@@ -21,4 +21,3 @@ thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
 tracing = { workspace = true }
-uuid = { workspace = true }

--- a/b4n-config/plugins.rs
+++ b/b4n-config/plugins.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use b4n_common::random_uuid;
 use notify::{EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 use serde::Deserialize;
 use std::ops::Deref;
@@ -11,7 +12,6 @@ use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use tokio::task::JoinHandle;
 use tokio::time::sleep;
 use tokio_util::sync::CancellationToken;
-use uuid::Uuid;
 
 use crate::{APP_NAME, keys::KeyCombination};
 
@@ -249,11 +249,4 @@ impl Drop for PluginsWatcher {
     fn drop(&mut self) {
         self.cancel();
     }
-}
-
-fn random_uuid() -> String {
-    Uuid::new_v4()
-        .hyphenated()
-        .encode_lower(&mut Uuid::encode_buffer())
-        .to_owned()
 }

--- a/b4n-kube/Cargo.toml
+++ b/b4n-kube/Cargo.toml
@@ -21,4 +21,3 @@ thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
 tracing = { workspace = true }
-uuid = { workspace = true }

--- a/b4n-kube/watcher/result.rs
+++ b/b4n-kube/watcher/result.rs
@@ -1,7 +1,7 @@
+use b4n_common::random_uuid;
 use kube::api::{ApiResource, DynamicObject};
 use kube::discovery::{ApiCapabilities, Scope, verbs};
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
-use uuid::Uuid;
 
 use crate::crds::CrdColumns;
 use crate::{CONTAINERS, ResourceRef};
@@ -70,10 +70,7 @@ impl InitData {
         let kind = if rt.is_container() { "Container" } else { ar.kind.as_str() };
         let kind_plural = if rt.is_container() { CONTAINERS } else { ar.plural.as_str() };
         Self {
-            uuid: Uuid::new_v4()
-                .hyphenated()
-                .encode_lower(&mut Uuid::encode_buffer())
-                .to_owned(),
+            uuid: random_uuid(),
             resource: rt.clone(),
             kind: kind.to_owned(),
             kind_plural: kind_plural.to_lowercase(),
@@ -91,10 +88,7 @@ impl InitData {
     /// Creates new simple initial data for [`ObserverResult`].
     pub fn simple(resource: ResourceRef, kind: String, kind_plural: String) -> Self {
         Self {
-            uuid: Uuid::new_v4()
-                .hyphenated()
-                .encode_lower(&mut Uuid::encode_buffer())
-                .to_owned(),
+            uuid: random_uuid(),
             resource,
             kind,
             kind_plural,

--- a/b4n-list/scrollable_list.rs
+++ b/b4n-list/scrollable_list.rs
@@ -474,6 +474,11 @@ impl<T: Row + Filterable<Fc>, Fc: FilterContext> ScrollableList<T, Fc> {
     /// Highlights element on list by the visible line number.
     pub fn highlight_item_by_line(&mut self, line_no: u16) -> bool {
         let index = self.page_start + usize::from(line_no);
+        self.highlight_item_by_index(index)
+    }
+
+    /// Highlights element on list by index.
+    pub fn highlight_item_by_index(&mut self, index: usize) -> bool {
         if index >= self.items.len() {
             return false;
         }

--- a/b4n-tasks/Cargo.toml
+++ b/b4n-tasks/Cargo.toml
@@ -22,4 +22,3 @@ thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
 tracing = {workspace = true }
-uuid = { workspace = true }

--- a/b4n-tasks/forwarder.rs
+++ b/b4n-tasks/forwarder.rs
@@ -1,4 +1,4 @@
-use b4n_common::{DEFAULT_ERROR_DURATION, NotificationSink};
+use b4n_common::{DEFAULT_ERROR_DURATION, NotificationSink, random_uuid};
 use b4n_kube::client::KubernetesClient;
 use b4n_kube::stats::{SharedStatistics, Statistics};
 use b4n_kube::{ContainerRef, PODS, ResourceRef};
@@ -16,7 +16,6 @@ use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tracing::warn;
-use uuid::Uuid;
 
 /// Possible errors from [`PortForwarder`].
 #[derive(thiserror::Error, Debug)]
@@ -222,10 +221,7 @@ impl PortForwardTask {
         };
 
         Self {
-            uuid: Uuid::new_v4()
-                .hyphenated()
-                .encode_lower(&mut Uuid::encode_buffer())
-                .to_owned(),
+            uuid: random_uuid(),
             resource: ResourceRef::default(),
             bind_address: String::default(),
             port: 0,

--- a/b4n-tasks/tasks/task.rs
+++ b/b4n-tasks/tasks/task.rs
@@ -1,6 +1,6 @@
+use b4n_common::random_uuid;
 use tokio::{runtime::Handle, sync::mpsc::UnboundedSender, task::JoinHandle};
 use tokio_util::sync::CancellationToken;
-use uuid::Uuid;
 
 use crate::commands::{Command, CommandResult};
 
@@ -21,10 +21,7 @@ impl PendingTask {
     /// Creates new [`PendingTask`] instance.
     pub fn new(command: Command, cancellation_token: CancellationToken) -> Self {
         Self {
-            id: Uuid::new_v4()
-                .hyphenated()
-                .encode_lower(&mut Uuid::encode_buffer())
-                .to_owned(),
+            id: random_uuid(),
             command,
             cancellation_token,
         }

--- a/b4n-tui/widgets/actions/action.rs
+++ b/b4n-tui/widgets/actions/action.rs
@@ -1,4 +1,4 @@
-use b4n_common::truncate;
+use b4n_common::{random_uuid, truncate};
 use b4n_kube::Port;
 use b4n_list::{BasicFilterContext, Filterable, Row};
 use std::{borrow::Cow, path::PathBuf};
@@ -27,7 +27,7 @@ impl ActionItem {
     /// Creates new [`ActionItem`] instance.
     pub fn new(name: &str) -> Self {
         Self {
-            uid: format!("_action:{name}_"),
+            uid: random_uuid(),
             group: "action".to_owned(),
             name: name.to_owned(),
             icon: Some(""),

--- a/b4n/ui/widgets/command_palette.rs
+++ b/b4n/ui/widgets/command_palette.rs
@@ -204,9 +204,14 @@ impl CommandPalette {
     }
 
     fn insert_highlighted_value(&mut self, overwrite_if_not_empty: bool) {
-        if self.select().is_anything_highlighted() && (self.select().value().is_empty() || overwrite_if_not_empty) {
+        let Some(uid) = self.select().items.list.get_highlighted_item_uid().map(String::from) else {
+            return;
+        };
+
+        if self.select().value().is_empty() || overwrite_if_not_empty {
             let value = self.select().items.get_highlighted_item_name().unwrap_or_default().to_owned();
             self.select_mut().set_value(value);
+            self.select_mut().items.list.highlight_item_by_uid(&uid);
         }
     }
 


### PR DESCRIPTION
This PR fixes command palette behaviour: when there are two elements on the list with the same name a wrong one can be selected by pressing enter.