### PR TITLE
Allow to enable system terminal cursor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## WIP
+## 0.5.2 - 2026-07-07
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 ### Features
 
+- add terminal settings (`system_cursor` and `scrollback_lines`) to the configuration file
 - new option `auto_mouse` for interactive plugins
 - new option `yaml_output` to highlight plugin output as YAML
-- add terminal settings (`system_cursor` and `scrollback_lines`) to the configuration file
 
 ### Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - new option `auto_mouse` for interactive plugins
 - new option `yaml_output` to highlight plugin output as YAML
+- add terminal settings (`system_cursor` and `scrollback_lines`) to the configuration file
 
 ### Bug fixes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,7 +211,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "b4n"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "ansi-to-tui",
  "anyhow",
@@ -242,7 +242,7 @@ dependencies = [
 
 [[package]]
 name = "b4n-common"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "base16ct",
@@ -259,7 +259,7 @@ dependencies = [
 
 [[package]]
 name = "b4n-config"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "b4n-common",
@@ -277,7 +277,7 @@ dependencies = [
 
 [[package]]
 name = "b4n-kube"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "b4n-common",
  "base64",
@@ -295,7 +295,7 @@ dependencies = [
 
 [[package]]
 name = "b4n-list"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "crossterm 0.29.0",
  "k8s-openapi",
@@ -303,7 +303,7 @@ dependencies = [
 
 [[package]]
 name = "b4n-tasks"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "b4n-common",
  "b4n-config",
@@ -322,7 +322,7 @@ dependencies = [
 
 [[package]]
 name = "b4n-tui"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "b4n-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.1"
+version = "0.5.2"
 edition = "2024"
 rust-version = "1.95"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -215,6 +215,9 @@ logs:
   lines: 800
   timestamps: true
 mouse: true
+terminal:
+  system_cursor: false
+  scrollback_lines: 1000
 theme: light
 contexts:
   test-cluster: '#43464f:#8aad81'
@@ -235,6 +238,8 @@ key_bindings:
 - `logs.lines` - Number of log lines to retrieve from the Kubernetes API for the selected container.
 - `logs.timestamps` - Whether timestamps are enabled by default for logs. You can still toggle this while viewing logs.
 - `mouse` - Whether mouse support is enabled when the application starts. You can also toggle it while the app is running.
+- `terminal.system_cursor` - If true all terminal views will stop drawing its own cursor and start using the system one.
+- `terminal.scrollback_lines` - A configurable maximum size limit of the terminal scrollback buffer.
 - `theme` - The name of the currently selected theme. This should match a file in the `themes` directory (without the `.yaml` extension).
 - `contexts` - _(Optional)_ A map of context names to their corresponding colors. Useful for highlighting important Kubernetes clusters with distinct header colors.
 - `aliases` - Command palette aliases.

--- a/assets/plugins/dive.yaml
+++ b/assets/plugins/dive.yaml
@@ -1,5 +1,5 @@
 # Example plugin that executes `dive` for the highlighted container
-# https://github.com/wagoodman/dive
+# Requires: https://github.com/wagoodman/dive
 
 name: dive
 aliases: []
@@ -15,6 +15,7 @@ confirm: false
 interactive: true
 keep_output: false
 keep_error: true
+yaml_output: false
 auto_mouse: false
 pin_to_top: false
 highlighted: true

--- a/b4n-config/config.rs
+++ b/b4n-config/config.rs
@@ -49,6 +49,22 @@ impl Default for Logs {
     }
 }
 
+/// Terminal configuration used in shell, attach and plugin views.
+#[derive(Serialize, Deserialize, Clone)]
+pub struct Terminal {
+    pub system_cursor: Option<bool>,
+    pub scrollback_lines: Option<usize>,
+}
+
+impl Default for Terminal {
+    fn default() -> Self {
+        Self {
+            system_cursor: Some(false),
+            scrollback_lines: Some(1_000),
+        }
+    }
+}
+
 /// Application configuration.
 #[derive(Serialize, Deserialize, Clone)]
 pub struct Config {
@@ -57,6 +73,9 @@ pub struct Config {
 
     #[serde(default = "default_mouse")]
     pub mouse: bool,
+
+    #[serde(default)]
+    pub terminal: Terminal,
 
     #[serde(default = "default_theme_name")]
     pub theme: String,
@@ -105,6 +124,7 @@ impl Default for Config {
         Self {
             logs: Logs::default(),
             mouse: default_mouse(),
+            terminal: Terminal::default(),
             theme: default_theme_name(),
             contexts: None,
             key_bindings: Some(KeyBindings::default()),

--- a/b4n/core/managers/views.rs
+++ b/b4n/core/managers/views.rs
@@ -214,7 +214,7 @@ impl ViewsManager {
             if response == ResponseEvent::Cancelled {
                 self.resources.process_external_view_close();
                 return ResponseEvent::Handled;
-            };
+            }
         }
 
         response
@@ -642,10 +642,7 @@ impl ViewsManager {
         }
         if result.is_err() {
             self.view = None;
-            return;
-        };
-
-        if let Some(view) = &mut self.view {
+        } else if let Some(view) = &mut self.view {
             view.process_command_result(CommandResult::RunPluginOutput(result));
         }
     }

--- a/b4n/core/managers/views.rs
+++ b/b4n/core/managers/views.rs
@@ -209,10 +209,12 @@ impl ViewsManager {
         };
 
         let response = view.process_event(event);
-        if response == ResponseEvent::Cancelled {
+        if response == ResponseEvent::Cancelled || response == ResponseEvent::ExitApplication {
             self.view = None;
-            self.resources.process_external_view_close();
-            return ResponseEvent::Handled;
+            if response == ResponseEvent::Cancelled {
+                self.resources.process_external_view_close();
+                return ResponseEvent::Handled;
+            };
         }
 
         response

--- a/b4n/ui/views/shell/cmd/view.rs
+++ b/b4n/ui/views/shell/cmd/view.rs
@@ -99,7 +99,7 @@ impl CmdView {
             is_app_mode: false,
             is_mouse_enabled: false,
             own_cursor,
-            cursor_shape: CursorShapeTracker::default(),
+            cursor_shape: CursorShapeTracker::new(!own_cursor),
             footer_tx,
         }
     }
@@ -460,7 +460,6 @@ impl View for CmdView {
 impl Drop for CmdView {
     fn drop(&mut self) {
         self.bridge.stop();
-        self.cursor_shape.reset_shape();
         self.app_data.disable_command(KeyCommand::ApplicationExit, false);
         self.app_data.disable_command(KeyCommand::MouseSupportToggle, false);
         self.footer_tx.hide_hint();

--- a/b4n/ui/views/shell/cmd/view.rs
+++ b/b4n/ui/views/shell/cmd/view.rs
@@ -62,7 +62,8 @@ impl CmdView {
         workspace: Rect,
     ) -> Self {
         let mut header = ContentHeader::new(Rc::clone(&app_data), false);
-        header.set_title(format!(" {}", plugin.name));
+        header.set_title(plugin.name);
+        header.set_icon('');
 
         let area = get_layout_with_header(workspace)[1];
         let command = plugin.command;
@@ -91,7 +92,7 @@ impl CmdView {
             area,
             esc_tracker: EscPressTracker::default(),
             auto_mouse: plugin.interactive && plugin.auto_mouse,
-            pin_to_top: !plugin.interactive && plugin.pin_to_top,
+            pin_to_top: plugin.keep_output && plugin.pin_to_top,
             keep_output: plugin.keep_output,
             keep_error: plugin.keep_error,
             is_finished: false,

--- a/b4n/ui/views/shell/cmd/view.rs
+++ b/b4n/ui/views/shell/cmd/view.rs
@@ -23,7 +23,7 @@ use crate::ui::views::{EscPressTracker, ScreenExt};
 use crate::ui::widgets::CommandPalette;
 use crate::ui::{presentation::ContentHeader, views::View};
 
-const SCROLLBACK_LEN: usize = 2_000;
+const SCROLLBACK_LEN: usize = 1_000;
 
 /// External interactive commands view.
 pub struct CmdView {
@@ -46,6 +46,7 @@ pub struct CmdView {
     is_finished: bool,
     is_app_mode: bool,
     is_mouse_enabled: bool,
+    own_cursor: bool,
     cursor_shape: CursorShapeTracker,
     footer_tx: NotificationSink,
 }
@@ -66,9 +67,11 @@ impl CmdView {
         let area = get_layout_with_header(workspace)[1];
         let command = plugin.command;
         let selection = ScreenSelection::default().with_color(app_data.borrow().theme.colors.shell.select);
-        let mut bridge = CmdBridge::new(runtime, area, SCROLLBACK_LEN);
+        let scrollback = app_data.borrow().config.terminal.scrollback_lines.unwrap_or(SCROLLBACK_LEN);
+        let mut bridge = CmdBridge::new(runtime, area, scrollback);
         bridge.start(command.clone(), args, plugin.current_dir, area.to_terminal_size());
         let parser = bridge.get_parser();
+        let own_cursor = app_data.borrow().config.terminal.system_cursor.is_none_or(|c| !c);
 
         app_data.disable_command(KeyCommand::ApplicationExit, true);
         app_data.disable_command(KeyCommand::MouseSupportToggle, true);
@@ -94,6 +97,7 @@ impl CmdView {
             is_finished: false,
             is_app_mode: false,
             is_mouse_enabled: false,
+            own_cursor,
             cursor_shape: CursorShapeTracker::default(),
             footer_tx,
         }
@@ -245,7 +249,7 @@ impl CmdView {
 
     fn reset_scrollback(&mut self, is_up: bool) -> ResponseEvent {
         if is_up {
-            self.scrollback_rows = SCROLLBACK_LEN + 1;
+            self.scrollback_rows = usize::MAX;
         } else {
             self.scrollback_rows = 0;
         }
@@ -432,12 +436,12 @@ impl View for CmdView {
 
             if let Ok(parser) = self.parser.read() {
                 let screen = parser.screen();
-                let cursor = Cursor::default().visibility(false);
+                let cursor = Cursor::default().visibility(self.own_cursor && has_focus && !self.hide_cursor());
                 let pseudo_term = PseudoTerminal::new(screen).cursor(cursor);
 
                 frame.render_widget(pseudo_term, layout[1]);
 
-                if has_focus && !self.hide_cursor() && !screen.hide_cursor() {
+                if !self.own_cursor && has_focus && !self.hide_cursor() && !screen.hide_cursor() {
                     frame.set_cursor_screen_position(screen, layout[1]);
                 }
             }

--- a/b4n/ui/views/shell/kube/view.rs
+++ b/b4n/ui/views/shell/kube/view.rs
@@ -102,7 +102,7 @@ impl ShellView {
             is_app_mode: false,
             is_mouse_enabled: false,
             own_cursor,
-            cursor_shape: CursorShapeTracker::default(),
+            cursor_shape: CursorShapeTracker::new(!own_cursor),
             footer_tx,
         }
     }
@@ -455,7 +455,6 @@ impl View for ShellView {
 impl Drop for ShellView {
     fn drop(&mut self) {
         self.bridge.stop();
-        self.cursor_shape.reset_shape();
         self.app_data.disable_command(KeyCommand::ApplicationExit, false);
         self.app_data.disable_command(KeyCommand::MouseSupportToggle, false);
         self.footer_tx.hide_hint();

--- a/b4n/ui/views/shell/kube/view.rs
+++ b/b4n/ui/views/shell/kube/view.rs
@@ -46,6 +46,7 @@ pub struct ShellView {
     is_attach: bool,
     is_app_mode: bool,
     is_mouse_enabled: bool,
+    own_cursor: bool,
     cursor_shape: CursorShapeTracker,
     footer_tx: NotificationSink,
 }
@@ -72,9 +73,11 @@ impl ShellView {
 
         let area = get_layout_with_header(workspace)[1];
         let selection = ScreenSelection::default().with_color(app_data.borrow().theme.colors.shell.select);
-        let mut bridge = ShellBridge::new(runtime, area, SCROLLBACK_LEN, is_attach);
+        let scrollback = app_data.borrow().config.terminal.scrollback_lines.unwrap_or(SCROLLBACK_LEN);
+        let mut bridge = ShellBridge::new(runtime, area, scrollback, is_attach);
         bridge.start(client.get_client(), pod.clone(), DEFAULT_SHELL, area.to_terminal_size());
         let parser = bridge.get_parser();
+        let own_cursor = app_data.borrow().config.terminal.system_cursor.is_none_or(|c| !c);
 
         app_data.disable_command(KeyCommand::ApplicationExit, true);
         app_data.disable_command(KeyCommand::MouseSupportToggle, true);
@@ -98,6 +101,7 @@ impl ShellView {
             is_attach,
             is_app_mode: false,
             is_mouse_enabled: false,
+            own_cursor,
             cursor_shape: CursorShapeTracker::default(),
             footer_tx,
         }
@@ -262,7 +266,7 @@ impl ShellView {
 
     fn reset_scrollback(&mut self, is_up: bool) -> ResponseEvent {
         if is_up {
-            self.scrollback_rows = SCROLLBACK_LEN + 1;
+            self.scrollback_rows = usize::MAX;
         } else {
             self.scrollback_rows = 0;
         }
@@ -428,12 +432,12 @@ impl View for ShellView {
 
             if let Ok(parser) = self.parser.read() {
                 let screen = parser.screen();
-                let cursor = Cursor::default().visibility(false);
+                let cursor = Cursor::default().visibility(self.own_cursor && has_focus && !self.hide_cursor());
                 let pseudo_term = PseudoTerminal::new(screen).cursor(cursor);
 
                 frame.render_widget(pseudo_term, layout[1]);
 
-                if has_focus && !self.hide_cursor() && !screen.hide_cursor() {
+                if !self.own_cursor && has_focus && !self.hide_cursor() && !screen.hide_cursor() {
                     frame.set_cursor_screen_position(screen, layout[1]);
                 }
             }

--- a/b4n/ui/views/shell/terminal.rs
+++ b/b4n/ui/views/shell/terminal.rs
@@ -297,15 +297,23 @@ impl TerminalState {
 }
 
 /// Tracks current cursor shape for the terminal.
-#[derive(Default)]
 pub struct CursorShapeTracker {
+    has_system_cursor: bool,
     cursor_shape: Option<CursorShape>,
 }
 
 impl CursorShapeTracker {
+    /// Creates new [`CursorShapeTracker`] instance.
+    pub fn new(has_system_cursor: bool) -> Self {
+        Self {
+            has_system_cursor,
+            cursor_shape: None,
+        }
+    }
+
     /// Apply new cursor shape to the terminal, if anything changed.
     pub fn sync_shape(&mut self, shape: CursorShape) {
-        if self.cursor_shape.is_none_or(|s| s != shape) {
+        if self.has_system_cursor && self.cursor_shape.is_none_or(|s| s != shape) {
             self.cursor_shape = Some(shape);
             self.apply_terminal_cursor_shape();
         }
@@ -313,8 +321,10 @@ impl CursorShapeTracker {
 
     /// Reset cursor shape for the terminal.
     pub fn reset_shape(&mut self) {
-        self.cursor_shape = Some(CursorShape::Default);
-        self.apply_terminal_cursor_shape();
+        if self.has_system_cursor {
+            self.cursor_shape = Some(CursorShape::Default);
+            self.apply_terminal_cursor_shape();
+        }
     }
 
     fn apply_terminal_cursor_shape(&self) {
@@ -329,6 +339,12 @@ impl CursorShapeTracker {
         };
 
         let _ = stdout().execute(command);
+    }
+}
+
+impl Drop for CursorShapeTracker {
+    fn drop(&mut self) {
+        self.reset_shape();
     }
 }
 


### PR DESCRIPTION
This PR adds configuration options to enable system terminal cursor (in some cases apps run as plugins requires more native cursor handling, like when they intentionally change cursor shape to something different than `b4n` uses).