### PR TITLE
chore: add macos targets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,11 @@ jobs:
           rust: stable
           target: x86_64-pc-windows-msvc
           target-short: x86_64-windows
+        - build: macos-arm
+          os: macos-latest
+          rust: stable
+          target: aarch64-apple-darwin
+          target-short: macos-aarch64
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build: [linux, win-msvc]
+        build: [linux, win-msvc, macos-x86, macos-arm]
         include:
         - build: linux
           os: ubuntu-24.04
@@ -60,13 +60,13 @@ jobs:
         - build: macos-x86
           os: macos-latest
           target: x86_64-apple-darwin
-          target-short: macos-x86_64
+          target-short: x86_64-macos
           rust: stable
         - build: macos-arm
           os: macos-latest
           rust: stable
           target: aarch64-apple-darwin
-          target-short: macos-aarch64
+          target-short: aarch64-macos
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,11 @@ jobs:
           rust: stable
           target: x86_64-pc-windows-msvc
           target-short: x86_64-windows
+        - build: macos-x86
+          os: macos-latest
+          target: x86_64-apple-darwin
+          target-short: macos-x86_64
+          rust: stable
         - build: macos-arm
           os: macos-latest
           rust: stable


### PR DESCRIPTION
adds older intel CPUs as well as modern M processors support

tar.gz is a perfect format for homebrew, I'll prepare a Formula in https://github.com/Homebrew/homebrew-core/ so it will auto-publish any future releases. No need to wait for 1.0 or any perfect timing :) 