### PR TITLE
Switch to directories crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## WIP
+## 0.5.6 - 2026-08-17
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## WIP
 
-## Features
+### Features
 
 - separate option for plugins to color `kubectl describe` output
 - configurable key bindings in edit mode
@@ -12,6 +12,18 @@
 
 - fix `kubectl describe` plugin run
 - do not create `default.yaml` theme file if it does not exist
+
+### Breaking changes
+
+- configuration files moved from `$HOME/.b4n/` to platform-specific directories:
+
+  | Platform | Config | Data |
+  |----------|--------|------|
+  | Windows | `%LOCALAPPDATA%\b4n\config\config.yaml` | `%LOCALAPPDATA%\b4n\data\` |
+  | macOS | `~/Library/Application Support/b4n/config/config.yaml` | `~/Library/Application Support/b4n/data/` |
+  | Linux | `~/.config/b4n/config.yaml` | `~/.local/share/b4n/` |
+
+  Migrate by copying your data (themes, plugins, etc.) from `$HOME/.b4n/` to the appropriate new locations, then delete the old directory. Run `b4n --show-dirs` to see the exact paths on your system.
 
 ## 0.5.5 - 2026-08-06
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,7 +57,7 @@ dependencies = [
  "ratatui-core",
  "simdutf8",
  "smallvec",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -233,7 +233,7 @@ dependencies = [
  "ratatui",
  "rstest",
  "syntect",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-util",
  "tracing",
@@ -247,7 +247,7 @@ dependencies = [
  "anyhow",
  "base16ct",
  "sha1 0.11.0",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "time",
  "tokio",
  "tracing",
@@ -270,7 +270,7 @@ dependencies = [
  "serde",
  "serde-saphyr",
  "syntect",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-util",
  "tracing",
@@ -289,7 +289,7 @@ dependencies = [
  "kube",
  "pin-project",
  "serde-saphyr",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-util",
  "tracing",
@@ -318,7 +318,7 @@ dependencies = [
  "shlex",
  "syntect",
  "tar",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "time",
  "tokio",
  "tokio-util",
@@ -463,9 +463,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.4.0"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
+checksum = "509591b7bcd67f4ef775afad7662703b4935daaa6ec0e5605cfb1090b32a2b6d"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -491,9 +491,9 @@ checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "clap"
-version = "4.6.5"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -501,9 +501,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.5"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
  "anstream",
  "anstyle",
@@ -825,7 +825,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
 dependencies = [
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -1020,9 +1020,9 @@ dependencies = [
 
 [[package]]
 name = "error-code"
-version = "3.3.2"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+checksum = "0b5343afd4a8365a643ac588dab4cf234a190c7f6c88c9f6dd6ffe00837661b7"
 
 [[package]]
 name = "euclid"
@@ -1092,9 +1092,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
 name = "finl_unicode"
@@ -1150,9 +1150,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
+checksum = "9a31d2a3fbaaeb2af2368bbdd904aa8e812d3c04a1ee10d3171f52d556e5d0a3"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1165,9 +1165,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
+checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1175,15 +1175,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
+checksum = "031b47cf1a3c6cc8bc2fc76cd437f521619387907d469316e7c0bc278f1f5432"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1192,32 +1192,32 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
+checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
 
 [[package]]
 name = "futures-task"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
 
 [[package]]
 name = "futures-timer"
@@ -1227,9 +1227,9 @@ checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 
 [[package]]
 name = "futures-util"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1393,9 +1393,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
+checksum = "23169fe34a5fbcdd3f3862e78fb9b6fccd5f02a6dc6f732547005d45631ce71c"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1516,9 +1516,9 @@ dependencies = [
 
 [[package]]
 name = "inotify"
-version = "0.11.4"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "153be1941a183ec9ccd095ddbe17a8b8d435ef6c76e9e02451b933c3999af2c8"
+checksum = "4cc00ea907cab49550b7da656f80ebb97be1b997d931fbcd28d39734e17ce592"
 dependencies = [
  "bitflags 2.13.1",
  "inotify-sys",
@@ -1616,7 +1616,7 @@ dependencies = [
  "jni-sys",
  "log",
  "simd_cesu8",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "walkdir",
  "windows-link",
 ]
@@ -1655,9 +1655,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1673,7 +1673,7 @@ dependencies = [
  "jsonptr",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -1686,7 +1686,7 @@ dependencies = [
  "pest_derive",
  "regex",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -1719,7 +1719,7 @@ checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
 dependencies = [
  "hashbrown 0.16.1",
  "portable-atomic",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -1783,7 +1783,7 @@ dependencies = [
  "serde",
  "serde-saphyr",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-tungstenite",
  "tokio-util",
@@ -1808,7 +1808,7 @@ dependencies = [
  "serde",
  "serde-value",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -1846,7 +1846,7 @@ dependencies = [
  "pin-project",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-util",
  "tracing",
@@ -2360,9 +2360,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.8.8"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7df728be843c7070fab6ab7c328c4e9e9d78e23bf749c0669c86ee7ebfa050a2"
+checksum = "5a07a60cc7a4d00c91f95c685609d1d2f79050e6804b70ebedd7650f0b839bcf"
 dependencies = [
  "memchr",
  "ucd-trie",
@@ -2370,9 +2370,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.8.8"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e2dd6fc3b26b3462ee188aac870f5a41d398f1cd5e2408d16531bd71c9591fd"
+checksum = "b3a83744a5c8455b8b3e0dc5031362780a347c878bdd11584d1a8984228cc88d"
 dependencies = [
  "pest",
  "pest_generator",
@@ -2380,9 +2380,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.8"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a7a9205cfb6f596a9e8b689c0a15f9ceb7a1aafae7aaf788150ac65b29975b6"
+checksum = "e0cd3451aa3de60d4b9a1e736885e4dea6b31617598026f12256ad566d63304a"
 dependencies = [
  "pest",
  "pest_meta",
@@ -2393,9 +2393,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.8.8"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85abd351c0de1e8384fc791a0737111a350394937e92b956b743dac12429f57c"
+checksum = "e04d3a0849e241d7dfce834c83b1c5edc8622009e8dd51a12ba1927c32f05496"
 dependencies = [
  "pest",
 ]
@@ -2480,9 +2480,9 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "plist"
@@ -2499,9 +2499,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
 
 [[package]]
 name = "portable-atomic-util"
@@ -2673,7 +2673,7 @@ dependencies = [
  "palette",
  "serde",
  "strum",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "unicode-segmentation",
  "unicode-truncate",
  "unicode-width",
@@ -2771,7 +2771,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -2972,9 +2972,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.13"
+version = "0.103.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+checksum = "0527518605e68109d875e248ea259b6758801cf165e4b2c2733ae3b51f12535a"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -3425,7 +3425,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "walkdir",
  "yaml-rust",
 ]
@@ -3551,11 +3551,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
- "thiserror-impl 2.0.19",
+ "thiserror-impl 2.0.20",
 ]
 
 [[package]]
@@ -3571,9 +3571,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3783,7 +3783,7 @@ checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
 dependencies = [
  "crossbeam-channel",
  "symlink",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "time",
  "tracing-subscriber",
 ]
@@ -3857,9 +3857,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tui-input"
-version = "0.15.3"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bd014a652e31cf25ea68d11b10a7b09549863449b19387505c9933f11eb05fa"
+checksum = "4eb7c7ddaef6dcc58fae905d0f89a3df49ef77e93822df7447a5bb0babc9ece3"
 dependencies = [
  "ratatui",
  "unicode-segmentation",
@@ -3890,7 +3890,7 @@ dependencies = [
  "log",
  "rand 0.9.5",
  "sha1 0.10.7",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -3954,9 +3954,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.24.0"
+version = "1.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
+checksum = "2cefc03fd367c0c6d4305de1b312cf00248c4114f4a0418ce6a6af769e3b0bd9"
 dependencies = [
  "atomic",
  "getrandom 0.4.3",
@@ -4043,9 +4043,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4056,9 +4056,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4066,9 +4066,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4079,9 +4079,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
 ]
@@ -4433,18 +4433,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.55"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.55"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,6 +264,7 @@ dependencies = [
  "anyhow",
  "b4n-common",
  "crossterm 0.29.0",
+ "directories",
  "notify",
  "ratatui-core",
  "serde",
@@ -891,6 +892,27 @@ dependencies = [
  "block-buffer 0.12.1",
  "const-oid",
  "crypto-common 0.2.2",
+]
+
+[[package]]
+name = "directories"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16f5094c54661b38d03bd7e50df373292118db60b585c08a411c6d840017fe7d"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1855,6 +1877,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "libredox"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d0a00925a9f930d679b6789b721e3a7f9ed110f41b86d2497caa780c3a070a"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "line-clipping"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2224,6 +2255,12 @@ name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-float"
@@ -2724,6 +2761,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags 2.13.1",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 2.0.19",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,7 +211,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "b4n"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "ansi-to-tui",
  "anyhow",
@@ -242,7 +242,7 @@ dependencies = [
 
 [[package]]
 name = "b4n-common"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "anyhow",
  "base16ct",
@@ -259,7 +259,7 @@ dependencies = [
 
 [[package]]
 name = "b4n-config"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "anyhow",
  "b4n-common",
@@ -278,7 +278,7 @@ dependencies = [
 
 [[package]]
 name = "b4n-kube"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "b4n-common",
  "base64",
@@ -297,7 +297,7 @@ dependencies = [
 
 [[package]]
 name = "b4n-list"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "crossterm 0.29.0",
  "k8s-openapi",
@@ -305,7 +305,7 @@ dependencies = [
 
 [[package]]
 name = "b4n-tasks"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "b4n-common",
  "b4n-config",
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "b4n-tui"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.5"
+version = "0.5.6"
 edition = "2024"
 rust-version = "1.95"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ base64 = { version = "0.22" }
 clap = { version = "4.6", features = ["derive", "env"] }
 crossterm = { version = "0.29", features = ["event-stream"] }
 delegate = { version = "0.13" }
+directories = { version = "6.0" }
 futures = { version = "0.3" }
 http = { version = "1" }
 jsonpath-rust = { version = "1" }

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   </a>
 </div>
 
-`b4n` is a terminal user interface (TUI) for the Kubernetes API, created mainly for learning the Rust programming language. It is heavily based on the [`k9s` project](https://k9scli.io) and built using the [`kube-rs`](https://kube.rs) and [`ratatui`](https://ratatui.rs) crates.
+`b4n` is a terminal user interface (TUI) for the Kubernetes API, created mainly for learning the Rust programming language. It is heavily inspired by the [`k9s` project](https://k9scli.io) and built using the [`kube-rs`](https://kube.rs) and [`ratatui`](https://ratatui.rs) crates.
 
 ![b4n demo](assets/b4n_048.gif?raw=true "b4n")
 
@@ -143,15 +143,39 @@ If the destination path (`To (dir):` textbox) contains `~`, there will be an att
 
 ## Configuration Files
 
-Configuration files are stored in the `$HOME/.b4n` directory. The layout looks like this:
+Configuration files are stored in platform-specific directories. The exact paths depend on your operating system:
+
+**Windows**
+```
+%LOCALAPPDATA%\b4n\config\config.yaml
+%LOCALAPPDATA%\b4n\data\history.yaml
+```
+> Example: `C:\Users\<user>\AppData\Local\b4n\`
+
+**macOS**
+```
+~/Library/Application Support/b4n/config/config.yaml
+~/Library/Application Support/b4n/data/history.yaml
+```
+
+**Linux**
+```
+~/.config/b4n/config.yaml
+~/.local/share/b4n/history.yaml
+```
+
+> Note: If the platform-specific directories cannot be determined, `b4n` falls back to `$HOME/.b4n/`.  
+> To list paths expected by the application: `b4n --show-dirs`
+
+The layout is as follows:
 
 ```
-.b4n/
+<config_dir>/
+└─ config.yaml
+<data_dir>/
 ├─ logs/
 ├─ plugins/
 ├─ themes/
-│  └─ default.yaml
-├─ config.yaml
 └─ history.yaml
 ```
 
@@ -207,14 +231,11 @@ for_each: false      # run each selected resource separately (if interactive: fa
 | `$COL[COLUMN_NAME]` | any visible column value from the highlighted or selected resource |
 | `$INPUT[NAME]`      | input's value provided by the user                                 |
 
-Example plugins are available in the `plugins` folder.
+The plugins folder is not created automatically. Example plugins are available in the `assets/plugins` folder.
 
 ### themes/
 
-This folder stores all TUI themes.  
-If `default.yaml` does not exist, the application will create it automatically.
-
-You can add more theme files here by copying the ones from the repository `themes` folder or by creating your own.
+This folder stores TUI themes. It is not created automatically. Place theme files here to make them available in the application - either by copying themes from the `assets/themes` folder or by creating your own.
 
 ### config.yaml
 

--- a/b4n-common/logging.rs
+++ b/b4n-common/logging.rs
@@ -1,17 +1,11 @@
 use anyhow::Result;
-use std::path::PathBuf;
+use std::path::Path;
 use tracing_error::ErrorLayer;
 use tracing_subscriber::{Layer, layer::SubscriberExt, util::SubscriberInitExt};
 
 /// Initializes new logging to file and returns worker guard that will flush logs on drop.
-pub fn initialize(app_name: &str) -> Result<tracing_appender::non_blocking::WorkerGuard> {
-    let home_dir = match std::env::home_dir() {
-        Some(mut path) => {
-            path.push(format!(".{app_name}/logs"));
-            path
-        },
-        None => PathBuf::from("logs"),
-    };
+pub fn initialize(app_name: &str, data_dir: &Path) -> Result<tracing_appender::non_blocking::WorkerGuard> {
+    let home_dir = data_dir.join("logs");
     let appender = tracing_appender::rolling::daily(home_dir, format!("{app_name}.log"));
     let (non_blocking_appender, guard) = tracing_appender::non_blocking(appender);
 

--- a/b4n-config/Cargo.toml
+++ b/b4n-config/Cargo.toml
@@ -12,6 +12,7 @@ path = "./lib.rs"
 b4n-common = { workspace = true }
 anyhow = { workspace = true }
 crossterm = { workspace = true }
+directories = { workspace = true }
 notify = { workspace = true }
 ratatui-core = { workspace = true }
 serde = { workspace = true }

--- a/b4n-config/config.rs
+++ b/b4n-config/config.rs
@@ -150,8 +150,8 @@ impl Default for Config {
 
 impl Config {
     /// Initialises project directories.\
-    /// **Note** that it must be called once on the app start.
-    pub fn init_dirs() -> Result<()> {
+    /// **Note** that it must be called once on app start.
+    pub fn init_dirs(create: bool) -> Result<()> {
         let (config_dir, data_dir) = if let Some(dirs) = ProjectDirs::from("", "", APP_NAME) {
             (dirs.config_local_dir().to_path_buf(), dirs.data_local_dir().to_path_buf())
         } else if let Some(home) = std::env::home_dir() {
@@ -162,8 +162,10 @@ impl Config {
             (app_dir.clone(), app_dir)
         };
 
-        std::fs::create_dir_all(&config_dir)?;
-        std::fs::create_dir_all(&data_dir)?;
+        if create {
+            std::fs::create_dir_all(&config_dir)?;
+            std::fs::create_dir_all(&data_dir)?;
+        }
 
         let _ = CONFIG_PATH.set(config_dir.join("config.yaml"));
         let _ = DATA_DIR.set(data_dir);
@@ -173,7 +175,6 @@ impl Config {
 
     /// Prints configuration paths used by the application.
     pub fn print_dirs(kube_config: Option<PathBuf>) {
-        println!("Resolved {} configuration paths:", APP_NAME.blue());
         println!("{}:     {}", "config".cyan(), Self::config_path().display());
         println!("{}:    {}", "history".cyan(), History::default_path().display());
         println!("{}:       {}", "logs".cyan(), Self::data_dir().join("logs").display());

--- a/b4n-config/config.rs
+++ b/b4n-config/config.rs
@@ -1,7 +1,9 @@
 use anyhow::Result;
+use directories::ProjectDirs;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
 use tokio::fs::File;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::runtime::Handle;
@@ -12,6 +14,9 @@ use crate::{ConfigWatcher, Persistable, keys::KeyBindings, utils::sorted_map};
 pub const APP_NAME: &str = "b4n";
 pub const APP_VERSION: &str = env!("CARGO_PKG_VERSION");
 pub const DEFAULT_THEME_NAME: &str = "default";
+
+static CONFIG_PATH: OnceLock<PathBuf> = OnceLock::new();
+static DATA_DIR: OnceLock<PathBuf> = OnceLock::new();
 
 /// Possible errors from configuration files manipulation.
 #[derive(thiserror::Error, Debug)]
@@ -142,22 +147,51 @@ impl Default for Config {
 }
 
 impl Config {
+    /// Initialises project directories.\
+    /// **Note** that it must be called once on the app start.
+    pub fn init_dirs() -> Result<()> {
+        let (config_dir, data_dir) = if let Some(dirs) = ProjectDirs::from("", "", APP_NAME) {
+            (dirs.config_local_dir().to_path_buf(), dirs.data_local_dir().to_path_buf())
+        } else if let Some(home) = std::env::home_dir() {
+            let app_dir = home.join(format!(".{APP_NAME}"));
+            (app_dir.clone(), app_dir)
+        } else {
+            let app_dir = PathBuf::from(".");
+            (app_dir.clone(), app_dir)
+        };
+
+        std::fs::create_dir_all(&config_dir)?;
+        std::fs::create_dir_all(&data_dir)?;
+
+        let _ = CONFIG_PATH.set(config_dir.join("config.yaml"));
+        let _ = DATA_DIR.set(data_dir);
+
+        Ok(())
+    }
+
     /// Returns watcher for configuration.
     pub fn watcher(runtime: Handle) -> ConfigWatcher<Config> {
         ConfigWatcher::new(runtime, Config::default_path())
     }
 
+    /// Returns path to the configuration file.
+    pub fn config_path() -> &'static Path {
+        CONFIG_PATH.get().expect("init_dirs was not called")
+    }
+
+    /// Retruns path to the data directory.
+    pub fn data_dir() -> &'static Path {
+        DATA_DIR.get().expect("init_dirs was not called")
+    }
+
     /// Returns path to the themes directory.
     pub fn themes_dir() -> PathBuf {
-        match std::env::home_dir() {
-            Some(path) => path.join(format!(".{APP_NAME}")).join("themes"),
-            None => PathBuf::from("themes"),
-        }
+        Self::data_dir().join("themes")
     }
 
     /// Loads the configuration from a file or creates a default one if the file does not exist.
     pub async fn load_or_create() -> (Self, Option<ConfigError>) {
-        load_configuration(&Self::default_path(), false, false).await
+        load_configuration(Self::config_path(), false, false).await
     }
 
     /// Loads the theme specified in the configuration.
@@ -178,12 +212,9 @@ impl Config {
 }
 
 impl Persistable<Config> for Config {
-    /// Returns the default configuration path: `$HOME/.b4n/config.yaml`.
+    /// Returns the default configuration path.
     fn default_path() -> PathBuf {
-        match std::env::home_dir() {
-            Some(path) => path.join(format!(".{APP_NAME}")).join("config.yaml"),
-            None => PathBuf::from("config.yaml"),
-        }
+        Self::config_path().to_path_buf()
     }
 
     async fn load(path: &Path) -> Result<Config, ConfigError> {

--- a/b4n-config/config.rs
+++ b/b4n-config/config.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use crossterm::style::Stylize;
 use directories::ProjectDirs;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -8,6 +9,7 @@ use tokio::fs::File;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::runtime::Handle;
 
+use crate::History;
 use crate::themes::{TextColors, Theme};
 use crate::{ConfigWatcher, Persistable, keys::KeyBindings, utils::sorted_map};
 
@@ -169,9 +171,19 @@ impl Config {
         Ok(())
     }
 
-    /// Returns watcher for configuration.
-    pub fn watcher(runtime: Handle) -> ConfigWatcher<Config> {
-        ConfigWatcher::new(runtime, Config::default_path())
+    /// Prints configuration paths used by the application.
+    pub fn print_dirs(kube_config: Option<PathBuf>) {
+        println!("Resolved {} configuration paths:", APP_NAME.blue());
+        println!("{}:     {}", "config".cyan(), Self::config_path().display());
+        println!("{}:    {}", "history".cyan(), History::default_path().display());
+        println!("{}:       {}", "logs".cyan(), Self::data_dir().join("logs").display());
+        println!("{}:     {}", "themes".cyan(), Self::themes_dir().display());
+        println!("{}:    {}", "plugins".cyan(), Self::plugins_dir().display());
+        if let Some(kube_config) = kube_config {
+            println!("{}: {}", "kubeconfig".cyan(), kube_config.display());
+        } else {
+            println!("{}: {}", "kubeconfig".cyan(), "not found".grey());
+        }
     }
 
     /// Returns path to the configuration file.
@@ -187,6 +199,16 @@ impl Config {
     /// Returns path to the themes directory.
     pub fn themes_dir() -> PathBuf {
         Self::data_dir().join("themes")
+    }
+
+    /// Returns path to the plugins directory.
+    pub fn plugins_dir() -> PathBuf {
+        Self::data_dir().join("plugins")
+    }
+
+    /// Returns watcher for configuration.
+    pub fn watcher(runtime: Handle) -> ConfigWatcher<Config> {
+        ConfigWatcher::new(runtime, Config::default_path())
     }
 
     /// Loads the configuration from a file or creates a default one if the file does not exist.

--- a/b4n-config/history.rs
+++ b/b4n-config/history.rs
@@ -10,7 +10,7 @@ use tokio::fs::File;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::runtime::Handle;
 
-use crate::{ConfigError, ConfigWatcher, Persistable};
+use crate::{Config, ConfigError, ConfigWatcher, Persistable};
 
 /// Keeps context configuration.
 #[derive(Serialize, Deserialize, Default, Clone)]
@@ -267,12 +267,9 @@ impl History {
 }
 
 impl Persistable<History> for History {
-    /// Returns the default history file path: `$HOME/.b4n/history.yaml`.
+    /// Returns the default history file path.
     fn default_path() -> PathBuf {
-        match std::env::home_dir() {
-            Some(path) => path.join(format!(".{}", super::APP_NAME)).join("history.yaml"),
-            None => PathBuf::from("history.yaml"),
-        }
+        Config::data_dir().join("history.yaml")
     }
 
     async fn load(path: &Path) -> Result<History, ConfigError> {

--- a/b4n-config/plugins.rs
+++ b/b4n-config/plugins.rs
@@ -13,7 +13,7 @@ use tokio::task::JoinHandle;
 use tokio::time::sleep;
 use tokio_util::sync::CancellationToken;
 
-use crate::{APP_NAME, keys::KeyCombination};
+use crate::keys::KeyCombination;
 
 /// Possible errors from plugins loading.
 #[derive(thiserror::Error, Debug)]
@@ -137,14 +137,6 @@ impl Deref for Plugins {
 }
 
 impl Plugins {
-    /// Returns the default plugins path: `$HOME/.b4n/plugins/`.
-    pub fn default_path() -> PathBuf {
-        match std::env::home_dir() {
-            Some(path) => path.join(format!(".{APP_NAME}")).join("plugins"),
-            None => PathBuf::from("plugins"),
-        }
-    }
-
     /// Loads plugins from the specified directory.
     pub async fn from_directory(path: &Path) -> Result<Self, PluginError> {
         let mut plugins = Vec::new();

--- a/b4n-config/themes/theme.rs
+++ b/b4n-config/themes/theme.rs
@@ -509,7 +509,7 @@ impl Theme {
 }
 
 impl Persistable<Theme> for Theme {
-    /// Returns the default theme file path: `$HOME/.b4n/themes/default.yaml`.
+    /// Returns the default theme file path.
     fn default_path() -> PathBuf {
         Config::themes_dir().join(format!("{DEFAULT_THEME_NAME}.yaml"))
     }

--- a/b4n-kube/client.rs
+++ b/b4n-kube/client.rs
@@ -147,6 +147,22 @@ impl DerefMut for KubernetesClient {
     }
 }
 
+/// Resolves `kubeconfig` path and checks if it exists.
+pub fn resolve_kube_config_path(kube_config_path: Option<&str>) -> Result<PathBuf, ClientError> {
+    let path = kube_config_path.map_or(
+        std::env::home_dir()
+            .map(|h| h.join(".kube").join("config"))
+            .ok_or(ClientError::HomeDirNotFound)?,
+        PathBuf::from,
+    );
+
+    if !path.exists() {
+        return Err(ClientError::KubeConfigNotFound);
+    }
+
+    Ok(path::absolute(path)?)
+}
+
 /// Returns matching context from the kube config for the provided one.\
 /// **Note** that it can `fallback_to_default` if the provided context is not found in kube config.
 pub async fn get_context(
@@ -260,18 +276,7 @@ fn get_context_internal(kube_config: &Kubeconfig, kube_context: Option<&str>) ->
 
 /// Returns kube config.
 async fn get_kube_config(kube_config_path: Option<&str>) -> Result<(Kubeconfig, Option<String>), ClientError> {
-    let path = kube_config_path.map_or(
-        std::env::home_dir()
-            .map(|h| h.join(".kube").join("config"))
-            .ok_or(ClientError::HomeDirNotFound)?,
-        PathBuf::from,
-    );
-
-    if !path.exists() {
-        return Err(ClientError::KubeConfigNotFound);
-    }
-
-    let path = path::absolute(path)?;
+    let path = resolve_kube_config_path(kube_config_path)?;
     let path_result = if kube_config_path.is_some() {
         Some(path.to_str().unwrap_or_default().to_string())
     } else {

--- a/b4n/cli.rs
+++ b/b4n/cli.rs
@@ -28,6 +28,10 @@ pub struct Args {
     /// Skip TLS certificate verification (insecure).
     #[arg(long)]
     pub insecure: bool,
+
+    /// Print configuration paths used by the application, then exit.
+    #[arg(long)]
+    pub show_dirs: bool,
 }
 
 impl Args {

--- a/b4n/cli.rs
+++ b/b4n/cli.rs
@@ -29,7 +29,7 @@ pub struct Args {
     #[arg(long)]
     pub insecure: bool,
 
-    /// Print configuration paths used by the application, then exit.
+    /// Print configuration paths used by the application.
     #[arg(long)]
     pub show_dirs: bool,
 }

--- a/b4n/core/app.rs
+++ b/b4n/core/app.rs
@@ -73,7 +73,7 @@ impl App {
             config_watcher: Config::watcher(runtime.clone()),
             history_watcher: History::watcher(runtime.clone()),
             theme_watcher: ConfigWatcher::new(runtime.clone(), theme_path),
-            plugins_watcher: PluginsWatcher::new(runtime, Config::data_dir().join("plugins")),
+            plugins_watcher: PluginsWatcher::new(runtime, Config::plugins_dir()),
             client_manager,
             views_manager,
         })

--- a/b4n/core/app.rs
+++ b/b4n/core/app.rs
@@ -155,11 +155,11 @@ impl App {
                 self.views_manager.footer().set_icon("000_notheme", None, IconKind::Error);
             },
             Some(Err(error))
-                if (!self.data.borrow().config.is_default_theme() || matches!(error, ConfigError::DeserializationError(_))) =>
+                if !self.data.borrow().config.is_default_theme() || matches!(error, ConfigError::DeserializationError(_)) =>
             {
                 let theme = &self.data.borrow().config.theme;
                 self.show_theme_error(format!("Error loading '{theme}' theme: {error}"));
-            },
+            }
             _ => (),
         }
 

--- a/b4n/core/app.rs
+++ b/b4n/core/app.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use b4n_common::{DEFAULT_ERROR_DURATION, DEFAULT_MESSAGE_DURATION, IconKind};
 use b4n_config::keys::{KeyBindings, KeyCommand};
 use b4n_config::themes::Theme;
-use b4n_config::{Config, ConfigError, ConfigWatcher, History, Plugins, PluginsWatcher, SyntaxData};
+use b4n_config::{Config, ConfigError, ConfigWatcher, History, PluginsWatcher, SyntaxData};
 use b4n_kube::{Kind, NAMESPACES, Namespace, ResourceRef};
 use b4n_tasks::commands::{
     Command, CommandResult, KubernetesClientError, KubernetesClientResult, ListKubeContextsCommand, ListThemesCommand,
@@ -73,7 +73,7 @@ impl App {
             config_watcher: Config::watcher(runtime.clone()),
             history_watcher: History::watcher(runtime.clone()),
             theme_watcher: ConfigWatcher::new(runtime.clone(), theme_path),
-            plugins_watcher: PluginsWatcher::new(runtime, Plugins::default_path()),
+            plugins_watcher: PluginsWatcher::new(runtime, Config::data_dir().join("plugins")),
             client_manager,
             views_manager,
         })

--- a/b4n/main.rs
+++ b/b4n/main.rs
@@ -17,7 +17,8 @@ pub mod ui;
 fn main() -> Result<()> {
     let args = cli::Args::parse();
 
-    let _logging_guard = b4n_common::logging::initialize(b4n_config::APP_NAME)?;
+    Config::init_dirs()?;
+    let _logging_guard = b4n_common::logging::initialize(b4n_config::APP_NAME, Config::data_dir())?;
     info!("{} v{} started", b4n_config::APP_NAME, b4n_config::APP_VERSION);
 
     if let Err(error) = run_application(&args) {

--- a/b4n/main.rs
+++ b/b4n/main.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use b4n_config::{Config, ConfigError, History};
 use b4n_kube::PODS;
-use b4n_kube::client::get_context;
+use b4n_kube::client::{get_context, resolve_kube_config_path};
 use clap::Parser;
 use core::{App, ExecutionFlow};
 use std::thread::sleep;
@@ -15,9 +15,13 @@ pub mod kube;
 pub mod ui;
 
 fn main() -> Result<()> {
-    let args = cli::Args::parse();
-
     Config::init_dirs()?;
+    let args = cli::Args::parse();
+    if args.show_dirs {
+        Config::print_dirs(resolve_kube_config_path(args.kube_config.as_deref()).ok());
+        return Ok(());
+    }
+
     let _logging_guard = b4n_common::logging::initialize(b4n_config::APP_NAME, Config::data_dir())?;
     info!("{} v{} started", b4n_config::APP_NAME, b4n_config::APP_VERSION);
 

--- a/b4n/main.rs
+++ b/b4n/main.rs
@@ -15,13 +15,14 @@ pub mod kube;
 pub mod ui;
 
 fn main() -> Result<()> {
-    Config::init_dirs()?;
     let args = cli::Args::parse();
     if args.show_dirs {
+        Config::init_dirs(false)?;
         Config::print_dirs(resolve_kube_config_path(args.kube_config.as_deref()).ok());
         return Ok(());
     }
 
+    Config::init_dirs(true)?;
     let _logging_guard = b4n_common::logging::initialize(b4n_config::APP_NAME, Config::data_dir())?;
     info!("{} v{} started", b4n_config::APP_NAME, b4n_config::APP_VERSION);
 


### PR DESCRIPTION
This PR introduces a **BREAKING CHANGE** in the configuration files placement:

  | Platform | Config | Data |
  |----------|--------|------|
  | Windows | `%LOCALAPPDATA%\b4n\config\config.yaml` | `%LOCALAPPDATA%\b4n\data\` |
  | macOS | `~/Library/Application Support/b4n/config/config.yaml` | `~/Library/Application Support/b4n/data/` |
  | Linux | `~/.config/b4n/config.yaml` | `~/.local/share/b4n/` |

  Migrate by copying your data (themes, plugins, etc.) from `$HOME/.b4n/` to the appropriate new locations, then delete the old directory. Run `b4n --show-dirs` to see the exact paths on your system.