### PR TITLE
Fix edit mode behaviour

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -735,12 +735,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.24.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88490bf1b990d87eaaa7ac8aa887f629a08e7359765b4911faf63c3763347d23"
+checksum = "ed17f5901b6630b993ca003def43f2f8ef4014fc13b047b57aad617ff32bc2ec"
 dependencies = [
- "darling_core 0.24.0",
- "darling_macro 0.24.0",
+ "darling_core 0.24.1",
+ "darling_macro 0.24.1",
 ]
 
 [[package]]
@@ -758,9 +758,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.24.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "084e274f91c482280130e1e34e0b8d6e66776a060d7b6de7b84289ca778868c4"
+checksum = "6837e2cf7485aaae18f86181d2f0e9a7ed297a025e220aeabf63fdebd3a2ddff"
 dependencies = [
  "ident_case",
  "proc-macro2",
@@ -782,11 +782,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.24.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f5792fa0d41cd2325ce0ffa64f0a340eaebd4971a3a0c5e1ffd2cc488a355e"
+checksum = "2ac7135c3ef02b2f7833bbeb1be5ba7f966dcde8a87c6b87f65a778d71a02785"
 dependencies = [
- "darling_core 0.24.0",
+ "darling_core 0.24.1",
  "quote",
  "syn 3.0.3",
 ]
@@ -1540,7 +1540,7 @@ version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bf84e73fa6f27f299dec58e13223cf70db80da872eb921d4f6138342a0eabc8"
 dependencies = [
- "darling 0.24.0",
+ "darling 0.24.1",
  "indoc",
  "proc-macro2",
  "quote",
@@ -2776,18 +2776,18 @@ dependencies = [
 
 [[package]]
 name = "ref-cast"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
+checksum = "7e440fb4e4b4147295338efb76001ab9e4efc0e5839df2c47fc5ac2381d365c3"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
+checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/b4n-kube/stats/metrics.tests.rs
+++ b/b4n-kube/stats/metrics.tests.rs
@@ -50,5 +50,5 @@ fn display_test() {
     let a = CpuMetrics::from_str("366455n").unwrap();
     let b = CpuMetrics::from_str("15m").unwrap();
     assert_eq!("15366455n", format!("{}", a + b));
-    assert_eq!("15m", format!("{}", (a + b).millicores()));
+    assert_eq!("15m", (a + b).millicores());
 }

--- a/b4n-tasks/commands/inject_container.rs
+++ b/b4n-tasks/commands/inject_container.rs
@@ -16,7 +16,7 @@ pub enum InjectContainerError {
         pod_name: String,
         container_name: String,
         #[source]
-        source: kube::Error,
+        source: Box<kube::Error>,
     },
 }
 
@@ -72,7 +72,7 @@ async fn inject_container(
     let pod = api.get(&name).await.map_err(|e| InjectContainerError::KubeError {
         pod_name: name.clone(),
         container_name: config.name.clone(),
-        source: e,
+        source: Box::new(e),
     })?;
 
     let mut ephemeral_containers = pod
@@ -97,7 +97,7 @@ async fn inject_container(
     .map_err(|e| InjectContainerError::KubeError {
         pod_name: name.clone(),
         container_name: config.name.clone(),
-        source: e,
+        source: Box::new(e),
     })?;
 
     Ok(ResourceRef::container(name, api.namespace().into(), config.name))

--- a/b4n-tasks/commands/set_yaml.rs
+++ b/b4n-tasks/commands/set_yaml.rs
@@ -19,7 +19,7 @@ pub enum SetResourceYamlError {
     SerializationError {
         resource: String,
         #[source]
-        source: serde_saphyr::Error,
+        source: Box<serde_saphyr::Error>,
     },
 
     /// Failed to patch or apply YAML to the Kubernetes resource.
@@ -28,7 +28,7 @@ pub enum SetResourceYamlError {
         action: SetResourceYamlAction,
         resource: String,
         #[source]
-        source: kube::Error,
+        source: Box<kube::Error>,
     },
 }
 
@@ -132,7 +132,7 @@ impl SetResourceYamlCommand {
         let mut resource = serde_saphyr::from_str::<k8s_openapi::serde_json::Value>(&self.yaml).map_err(|e| {
             SetResourceYamlError::SerializationError {
                 resource: self.name.clone(),
-                source: e,
+                source: Box::new(e),
             }
         })?;
 
@@ -160,7 +160,7 @@ impl SetResourceYamlCommand {
             .map_err(|e| SetResourceYamlError::PatchError {
                 action: self.options.action,
                 resource: self.name.clone(),
-                source: e,
+                source: Box::new(e),
             })?;
 
         if let Some(status) = status_part
@@ -177,7 +177,7 @@ impl SetResourceYamlCommand {
                 .map_err(|e| SetResourceYamlError::PatchError {
                     action: self.options.action,
                     resource: self.name.clone(),
-                    source: e,
+                    source: Box::new(e),
                 })?;
         }
 

--- a/b4n/ui/presentation/content/edit.rs
+++ b/b4n/ui/presentation/content/edit.rs
@@ -103,7 +103,7 @@ impl EditContext {
                 }
             },
             TuiEvent::Command(command) => {
-                if let Some(pos) = self.process_command(command, content, selection) {
+                if let Some(pos) = self.process_command(*command, content, selection) {
                     self.update_cursor_position(pos, content, false);
                 }
             },
@@ -114,7 +114,7 @@ impl EditContext {
 
     fn process_command<T: Content>(
         &mut self,
-        command: &KeyCommand,
+        command: KeyCommand,
         content: &mut T,
         selection: Option<Selection>,
     ) -> Option<NewCursorPosition> {

--- a/b4n/ui/presentation/content/edit.rs
+++ b/b4n/ui/presentation/content/edit.rs
@@ -13,6 +13,7 @@ use crate::ui::presentation::content::{Content, search::ContentPosition};
 
 /// Context for the content edit mode.
 pub struct EditContext {
+    pub was_enabled: bool,
     pub is_enabled: bool,
     pub is_modified: bool,
     pub cursor: ContentPosition,
@@ -26,6 +27,7 @@ impl EditContext {
     /// Creates new [`EditContext`] instance.
     pub fn new(app_data: SharedAppData, cursor_color: TextColors) -> Self {
         Self {
+            was_enabled: false,
             is_enabled: false,
             is_modified: false,
             cursor: ContentPosition::default(),
@@ -45,6 +47,7 @@ impl EditContext {
         page_size: u16,
         content: &mut T,
     ) {
+        self.was_enabled = true;
         self.is_enabled = true;
         if let Some(selection) = selection {
             self.cursor = get_cursor_pos_for_selection(content, selection.end, selection.is_end_after_start());

--- a/b4n/ui/presentation/content/viewer.rs
+++ b/b4n/ui/presentation/content/viewer.rs
@@ -137,14 +137,17 @@ impl<T: Content> ContentViewer<T> {
             return false;
         }
 
-        let cursor_start = if is_new && let Some(content) = self.content() {
-            content
-                .search_first("  name: \"\"")
-                .or_else(|| content.search_first("  name: ''"))
-                .map(|start| ContentPosition::new(start.x + start.length.saturating_sub(1), start.y))
-        } else {
-            self.current_match_position()
-        };
+        let cursor_start = self.current_match_position().or_else(|| {
+            let is_new_first_time = is_new && !self.edit.was_enabled;
+            if is_new_first_time && let Some(content) = self.content() {
+                content
+                    .search_first("  name: \"\"")
+                    .or_else(|| content.search_first("  name: ''"))
+                    .map(|start| ContentPosition::new(start.x + start.length.saturating_sub(1), start.y))
+            } else {
+                None
+            }
+        });
         if let Some(content) = &mut self.content
             && content.is_editable()
         {

--- a/b4n/ui/presentation/utils.rs
+++ b/b4n/ui/presentation/utils.rs
@@ -225,7 +225,7 @@ fn remove_lines(lines: &mut Vec<String>, start_line: usize, end_line: usize, sta
     let last = if let Some(end) = char_to_index(&lines[end_line], end + 1) {
         lines[end_line].drain(..end).collect()
     } else {
-        lines[end_line].drain(..).collect()
+        std::mem::take(&mut lines[end_line])
     };
 
     if is_end_eol {

--- a/b4n/ui/views/yaml/view.rs
+++ b/b4n/ui/views/yaml/view.rs
@@ -281,9 +281,7 @@ impl YamlView {
             }
 
             let is_modified = self.yaml.is_modified();
-            if self.is_edit && !is_modified {
-                return ResponseEvent::Cancelled;
-            } else if self.yaml.disable_edit_mode() {
+            if self.yaml.disable_edit_mode() {
                 if is_modified {
                     self.show_edit_hint(true);
                 } else {

--- a/b4n/ui/views/yaml/view.rs
+++ b/b4n/ui/views/yaml/view.rs
@@ -276,10 +276,6 @@ impl YamlView {
         }
 
         if self.app_data.has_binding(event, KeyCommand::NavigateBack) {
-            if self.is_new {
-                return self.process_view_close_event(ResponseEvent::Cancelled, false);
-            }
-
             let is_modified = self.yaml.is_modified();
             if self.yaml.disable_edit_mode() {
                 if is_modified {
@@ -707,16 +703,11 @@ impl YamlView {
     fn show_edit_hint(&mut self, is_modified: bool) {
         self.is_hint_visible = true;
         let key = self.app_data.get_key_name(KeyCommand::NavigateBack).to_ascii_uppercase();
-        if self.is_new {
-            self.footer
-                .show_hint(format!(" Press ␝{key}␝ to open save dialog (if modified)"));
+        self.footer.show_hint(if is_modified {
+            format!(" Press ␝{key}␝ for save dialog")
         } else {
-            self.footer.show_hint(if is_modified {
-                format!(" Press ␝{key}␝ for save dialog")
-            } else {
-                format!(" Press ␝{key}␝ to close edit mode, then ␝{key}␝ for save dialog (if modified)")
-            });
-        }
+            format!(" Press ␝{key}␝ to close edit mode, then ␝{key}␝ for save dialog (if modified)")
+        });
     }
 
     fn hide_edit_hint(&mut self) {


### PR DESCRIPTION
This PR changes how edit existing resource and create new one behaves. From now on both allow to exit edit mode to the view mode first, before exiting completely (also if content is unmodified). This allows to e.g. search the content and go back to edit mode.