### PR TITLE
More kubeconfig options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - add `--cluster` and `--user` options to overwrite context configuration
+- allow to impersonate as a different user during the session
 
 ### Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,13 @@
 
 ### Features
 
-- add `--cluster` and `--user` options to overwrite context configuration
-- allow to impersonate as a different user during the session
+- add `--cluster` and `--user` options to override context configuration
+- add `--as` and `--as-group` options to impersonate a user during the session
+- add `--client-cert`, `--client-key`, and `--ca` options for custom TLS authentication
 
-### Bug fixes
+### Bug Fixes
 
-- fix mouse menu not working properly in YAML edit mode
+- fix mouse menu not working in YAML edit mode
 
 ## 0.5.6 - 2026-08-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## WIP
 
+### Features
+
+- add `--cluster` and `--user` options to overwrite context configuration
+
 ### Bug fixes
 
 - fix mouse menu not working properly in YAML edit mode

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.96-alpine AS builder
+FROM rust:1.98-alpine AS builder
 
 RUN apk add --no-cache musl-dev build-base
 

--- a/b4n-config/config.rs
+++ b/b4n-config/config.rs
@@ -174,14 +174,14 @@ impl Config {
     }
 
     /// Prints configuration paths used by the application.
-    pub fn print_dirs(kube_config: Option<PathBuf>) {
+    pub fn print_dirs(kubeconfig: Option<PathBuf>) {
         println!("{}:     {}", "config".cyan(), Self::config_path().display());
         println!("{}:    {}", "history".cyan(), History::default_path().display());
         println!("{}:       {}", "logs".cyan(), Self::data_dir().join("logs").display());
         println!("{}:     {}", "themes".cyan(), Self::themes_dir().display());
         println!("{}:    {}", "plugins".cyan(), Self::plugins_dir().display());
-        if let Some(kube_config) = kube_config {
-            println!("{}: {}", "kubeconfig".cyan(), kube_config.display());
+        if let Some(kubeconfig) = kubeconfig {
+            println!("{}: {}", "kubeconfig".cyan(), kubeconfig.display());
         } else {
             println!("{}: {}", "kubeconfig".cyan(), "not found".grey());
         }

--- a/b4n-config/history.rs
+++ b/b4n-config/history.rs
@@ -44,7 +44,7 @@ impl ContextInfo {
     }
 }
 
-/// Keeps context configuration for individual kube config.
+/// Keeps context configuration for individual kubeconfig.
 #[derive(Serialize, Deserialize, Default, Clone)]
 pub struct KubeConfig {
     pub current_context: Option<String>,
@@ -69,9 +69,9 @@ static EMPTY_LIST: Vec<HistoryItem> = Vec::new();
 /// Application history.
 #[derive(Serialize, Deserialize, Default, Clone)]
 pub struct History {
-    pub kube_configs: HashMap<String, KubeConfig>,
+    pub kubeconfigs: HashMap<String, KubeConfig>,
     #[serde(skip_serializing)]
-    current_kube_config: Option<String>,
+    current_kubeconfig: Option<String>,
     #[serde(skip_serializing)]
     current_hash: Option<String>,
 }
@@ -99,7 +99,7 @@ impl History {
     /// Returns a kind stored in the history under a specific context name.
     pub fn get_kind(&self, context: &str) -> Option<&str> {
         if let Some(index) = self.context_index(context) {
-            Some(&self.kube_configs[self.config_key()].contexts[index].kind)
+            Some(&self.kubeconfigs[self.config_key()].contexts[index].kind)
         } else {
             None
         }
@@ -108,25 +108,25 @@ impl History {
     /// Returns a namespace stored in the history under a specific context name.
     pub fn get_namespace(&self, context: &str) -> Option<&str> {
         if let Some(index) = self.context_index(context) {
-            Some(&self.kube_configs[self.config_key()].contexts[index].namespace)
+            Some(&self.kubeconfigs[self.config_key()].contexts[index].namespace)
         } else {
             None
         }
     }
 
-    /// Gets the currently used kube config path.
-    pub fn kube_config_path(&self) -> Option<&str> {
-        self.current_kube_config.as_deref()
+    /// Gets the currently used kubeconfig path.
+    pub fn kubeconfig_path(&self) -> Option<&str> {
+        self.current_kubeconfig.as_deref()
     }
 
-    /// Sets the currently used kube config path.
-    pub fn set_kube_config_path(&mut self, path: Option<String>) {
+    /// Sets the currently used kubeconfig path.
+    pub fn set_kubeconfig_path(&mut self, path: Option<String>) {
         if let Some(path) = path {
             self.current_hash = Some(calculate_hash(&path, 8));
-            self.current_kube_config = Some(path);
+            self.current_kubeconfig = Some(path);
         } else {
             self.current_hash = None;
-            self.current_kube_config = None;
+            self.current_kubeconfig = None;
         }
     }
 
@@ -148,52 +148,52 @@ impl History {
 
             config.current_context = Some(context);
         } else {
-            self.kube_configs
+            self.kubeconfigs
                 .insert(self.config_key().to_owned(), KubeConfig::new(context, kind, namespace));
         }
     }
 
-    /// Gets `filter_history` from the specified `context` of the current kube config.
+    /// Gets `filter_history` from the specified `context` of the current kubeconfig.
     pub fn filter_history(&self, context: &str) -> &[HistoryItem] {
         self.get_history(context, |c| &c.filter_history)
     }
 
-    /// Puts item to `filter_history` in the specified `context` of the current kube config.
+    /// Puts item to `filter_history` in the specified `context` of the current kubeconfig.
     pub fn put_filter_history_item(&mut self, context: &str, item: HistoryItem, max_list_size: usize) {
         self.put_history_item_to(context, item, max_list_size, |c| &mut c.filter_history);
     }
 
-    /// Removes an item from `filter_history` in the specified `context` of the current kube config.
+    /// Removes an item from `filter_history` in the specified `context` of the current kubeconfig.
     pub fn remove_filter_history_item(&mut self, context: &str, item: &str) -> Option<HistoryItem> {
         self.remove_history_item_from(context, item, |c| &mut c.filter_history)
     }
 
-    /// Gets `search_history` from the specified `context` of the current kube config.
+    /// Gets `search_history` from the specified `context` of the current kubeconfig.
     pub fn search_history(&self, context: &str) -> &[HistoryItem] {
         self.get_history(context, |c| &c.search_history)
     }
 
-    /// Puts item to `search_history` in the specified `context` of the current kube config.
+    /// Puts item to `search_history` in the specified `context` of the current kubeconfig.
     pub fn put_search_history_item(&mut self, context: &str, item: HistoryItem, max_list_size: usize) {
         self.put_history_item_to(context, item, max_list_size, |c| &mut c.search_history);
     }
 
-    /// Removes an item from `search_history` in the specified `context` of the current kube config.
+    /// Removes an item from `search_history` in the specified `context` of the current kubeconfig.
     pub fn remove_search_history_item(&mut self, context: &str, item: &str) -> Option<HistoryItem> {
         self.remove_history_item_from(context, item, |c| &mut c.search_history)
     }
 
-    /// Gets `namespace_history` from the specified `context` of the current kube config.
+    /// Gets `namespace_history` from the specified `context` of the current kubeconfig.
     pub fn namespace_history(&self, context: &str) -> &[HistoryItem] {
         self.get_history(context, |c| &c.namespace_history)
     }
 
-    /// Puts item to `namespace_history` in the specified `context` of the current kube config.
+    /// Puts item to `namespace_history` in the specified `context` of the current kubeconfig.
     pub fn put_namespace_history_item(&mut self, context: &str, item: HistoryItem, max_list_size: usize) {
         self.put_history_item_to(context, item, max_list_size, |c| &mut c.namespace_history);
     }
 
-    /// Removes an item from `namespace_history` in the specified `context` of the current kube config.
+    /// Removes an item from `namespace_history` in the specified `context` of the current kubeconfig.
     pub fn remove_namespace_history_item(&mut self, context: &str, item: &str) -> Option<HistoryItem> {
         self.remove_history_item_from(context, item, |c| &mut c.namespace_history)
     }
@@ -206,13 +206,13 @@ impl History {
     }
 
     fn context_index(&self, context: &str) -> Option<usize> {
-        self.kube_configs
+        self.kubeconfigs
             .get(self.config_key())
             .and_then(|c| c.contexts.iter().position(|c| c.name == context))
     }
 
     fn current_config(&self) -> Option<&KubeConfig> {
-        self.kube_configs.get(self.config_key())
+        self.kubeconfigs.get(self.config_key())
     }
 
     fn current_config_mut(&mut self) -> Option<&mut KubeConfig> {
@@ -221,7 +221,7 @@ impl History {
             None => "default",
         };
 
-        self.kube_configs.get_mut(current_key)
+        self.kubeconfigs.get_mut(current_key)
     }
 
     fn get_history<'a>(&'a self, context: &str, field: fn(&'a ContextInfo) -> &'a Vec<HistoryItem>) -> &'a [HistoryItem] {

--- a/b4n-kube/client.rs
+++ b/b4n-kube/client.rs
@@ -68,6 +68,7 @@ pub struct ClientOptions {
 }
 
 impl ClientOptions {
+    /// Creates new [`ClientOptions`] instance.
     pub fn new(allow_insecure: bool) -> Self {
         Self {
             cluster: None,
@@ -79,6 +80,48 @@ impl ClientOptions {
             certificate_authority: None,
             allow_insecure,
         }
+    }
+
+    /// Returns `true` if options have overrides for cluster, user or impersonation.
+    pub fn has_overrides(&self) -> bool {
+        self.cluster.is_some()
+            || self.user.is_some()
+            || self.as_user.is_some()
+            || self.as_groups.as_ref().is_some_and(|g| !g.is_empty())
+    }
+}
+
+impl std::fmt::Display for ClientOptions {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut sep = "";
+
+        if let Some(cluster) = &self.cluster {
+            write!(f, "cluster: {cluster}")?;
+            sep = ", ";
+        }
+
+        if let Some(user) = &self.user {
+            write!(f, "{sep}user: {user}")?;
+            sep = ", ";
+        }
+
+        if let Some(as_user) = &self.as_user {
+            write!(f, "{sep}as: {as_user}")?;
+            sep = ", ";
+        }
+
+        if let Some(as_groups) = &self.as_groups
+            && !as_groups.is_empty()
+        {
+            write!(f, "{sep}as-groups: ")?;
+            sep = "";
+            for group in as_groups {
+                write!(f, "{sep}{group}")?;
+                sep = ", ";
+            }
+        }
+
+        Ok(())
     }
 }
 
@@ -99,16 +142,9 @@ impl From<&NamedContext> for ContextInfo {
 
 /// Wrapper for the kubernetes [`Client`].
 pub struct KubernetesClient {
-    /// Kubernetes client.
     client: Client,
-
-    /// Kubeconfig path.
     kubeconfig_path: Option<String>,
-
-    /// Context used by the kubernetes client.
     context: String,
-
-    /// Kubernetes API version that the client is connected to.
     k8s_version: String,
 }
 

--- a/b4n-kube/client.rs
+++ b/b4n-kube/client.rs
@@ -16,20 +16,28 @@ pub enum ClientError {
     #[error("failed to determine user's home directory")]
     HomeDirNotFound,
 
-    /// Kube config file not found.
-    #[error("kube config file not found")]
+    /// Kubeconfig file not found.
+    #[error("kubeconfig file not found")]
     KubeConfigNotFound,
 
-    /// Context not found in kube config.
-    #[error("context not found in kube config")]
-    ContextNotFound,
+    /// Context not found in kubeconfig.
+    #[error("Kube context '{0}' not found in configuration.")]
+    ContextNotFound(String),
+
+    /// Cluster not found in kubeconfig.
+    #[error("Kube cluster '{0}' not found in configuration.")]
+    ClusterNotFound(String),
+
+    /// User not found in kubeconfig.
+    #[error("Kube user '{0}' not found in configuration.")]
+    UserNotFound(String),
 
     /// Failed to read kube configuration.
-    #[error("cannot read kube config: {0}")]
+    #[error("cannot read kubeconfig: {0}")]
     IoError(#[from] std::io::Error),
 
     /// Failed to process kube configuration.
-    #[error("cannot build kube config: {0}")]
+    #[error("cannot build kubeconfig: {0}")]
     KubeconfigError(#[from] kube::config::KubeconfigError),
 
     /// Failed to build kubernetes client.
@@ -80,7 +88,7 @@ pub struct KubernetesClient {
     /// Kubernetes client.
     client: Client,
 
-    /// Kube config path.
+    /// Kubeconfig path.
     kubeconfig_path: Option<String>,
 
     /// Context used by the kubernetes client.
@@ -128,7 +136,7 @@ impl KubernetesClient {
         get_dynamic_api(ar, caps, self.client.clone(), ns, all)
     }
 
-    /// Returns path to kube config used to create this client.
+    /// Returns path to kubeconfig used to create this client.
     pub fn kubeconfig_path(&self) -> Option<&str> {
         self.kubeconfig_path.as_deref()
     }
@@ -174,29 +182,44 @@ pub fn resolve_kubeconfig_path(kubeconfig_path: Option<&str>) -> Result<PathBuf,
     Ok(path::absolute(path)?)
 }
 
-/// Returns matching context from the kube config for the provided one.\
-/// **Note** that it can `fallback_to_default` if the provided context is not found in kube config.
-pub async fn get_context(
+/// Validates provided configuration and returns matching context from the kubeconfig.\
+/// **Note** that it can `fallback_to_default` if the provided context is not found in kubeconfig.
+pub async fn validate_and_resolve_context(
     kubeconfig_path: Option<&str>,
     context: Option<&str>,
+    cluster: Option<&str>,
+    user: Option<&str>,
     fallback_to_default: bool,
-) -> Result<(Option<ContextInfo>, Option<String>), ClientError> {
+) -> Result<(ContextInfo, Option<String>), ClientError> {
     let (kubeconfig, kubeconfig_path) = get_kubeconfig(kubeconfig_path).await?;
+
+    if let Some(cluster_name) = cluster
+        && kubeconfig.clusters.iter().find(|c| c.name == cluster_name).is_none()
+    {
+        return Err(ClientError::ClusterNotFound(cluster_name.to_string()));
+    }
+
+    if let Some(user_name) = user
+        && kubeconfig.auth_infos.iter().find(|c| c.name == user_name).is_none()
+    {
+        return Err(ClientError::UserNotFound(user_name.to_string()));
+    }
+
     if let Some(context_name) = context
         && let Some(context) = kubeconfig.contexts.iter().find(|c| c.name == context_name)
     {
-        Ok((Some(context.into()), kubeconfig_path))
+        Ok((context.into(), kubeconfig_path))
     } else if fallback_to_default
         && let Some(context_name) = kubeconfig.current_context.as_deref()
         && let Some(context) = kubeconfig.contexts.iter().find(|c| c.name == context_name)
     {
-        Ok((Some(context.into()), kubeconfig_path))
+        Ok((context.into(), kubeconfig_path))
     } else {
-        Ok((None, kubeconfig_path))
+        Err(ClientError::ContextNotFound(context.unwrap_or("default").to_string()))
     }
 }
 
-/// Returns contexts from the kube config.
+/// Returns contexts from the kubeconfig.
 pub async fn list_contexts(kubeconfig_path: Option<&str>) -> Result<Vec<NamedContext>, ClientError> {
     let (kubeconfig, _) = get_kubeconfig(kubeconfig_path).await?;
     Ok(kubeconfig.contexts)
@@ -228,7 +251,7 @@ async fn get_client(
     if let Some(context) = get_context_internal(&kubeconfig, context) {
         Ok((get_client_for_context(kubeconfig, &context, options).await?, context))
     } else {
-        Err(ClientError::ContextNotFound)
+        Err(ClientError::ContextNotFound(context.unwrap_or("default").to_string()))
     }
 }
 
@@ -261,7 +284,7 @@ fn get_context_internal(kubeconfig: &Kubeconfig, context: Option<&str>) -> Optio
     context.map(|context| context.name.clone())
 }
 
-/// Returns kube config.
+/// Returns kubeconfig.
 async fn get_kubeconfig(kubeconfig_path: Option<&str>) -> Result<(Kubeconfig, Option<String>), ClientError> {
     let path = resolve_kubeconfig_path(kubeconfig_path)?;
     let path_result = if kubeconfig_path.is_some() {

--- a/b4n-kube/client.rs
+++ b/b4n-kube/client.rs
@@ -43,24 +43,23 @@ pub enum ClientError {
     /// Failed to build kubernetes client.
     #[error("cannot create client: {0}")]
     KubeError(#[from] kube::Error),
+
+    /// Cannot join client creation task.
+    #[error("task join error: {0}")]
+    TaskJoin(#[from] tokio::task::JoinError),
 }
 
 /// Options for the Kubernetes client.
 #[derive(Clone)]
 pub struct ClientOptions {
-    /// Cluster to use instead of the one set in context.
     pub cluster: Option<String>,
-
-    /// User to use instead of the one set in context.
     pub user: Option<String>,
-
-    /// User to impersonate.
     pub as_user: Option<String>,
-
-    /// Groups to impersonate.
     pub as_groups: Option<Vec<String>>,
 
-    /// Allow insecure connections (do not verify TLS certificate).
+    pub client_cert: Option<String>,
+    pub client_key: Option<String>,
+    pub certificate_authority: Option<String>,
     pub allow_insecure: bool,
 }
 
@@ -71,6 +70,9 @@ impl ClientOptions {
             user: None,
             as_user: None,
             as_groups: None,
+            client_cert: None,
+            client_key: None,
+            certificate_authority: None,
             allow_insecure,
         }
     }
@@ -274,14 +276,17 @@ async fn get_client_for_context(kubeconfig: Kubeconfig, context: &str, options: 
     let mut config = Config::from_custom_kubeconfig(kubeconfig, &kubeconfig_options).await?;
     config.auth_info.impersonate = options.as_user;
     config.auth_info.impersonate_groups = options.as_groups;
+    config.auth_info.client_certificate = options.client_cert;
+    config.auth_info.client_key = options.client_key;
     config.accept_invalid_certs = options.allow_insecure;
+    config.root_cert_file = options.certificate_authority.as_ref().map(PathBuf::from);
 
     let fixed_url = config.cluster_url.to_string().replace("0.0.0.0", "127.0.0.1");
     if let Ok(uri) = Uri::from_str(&fixed_url) {
         config.cluster_url = uri;
     }
 
-    Ok(Client::try_from(config)?)
+    Ok(tokio::task::spawn_blocking(move || Client::try_from(config)).await??)
 }
 
 /// Returns provided context (or default one if `None` specified).

--- a/b4n-kube/client.rs
+++ b/b4n-kube/client.rs
@@ -51,8 +51,14 @@ pub struct ClientOptions {
     /// Cluster to use instead of the one set in context.
     pub cluster: Option<String>,
 
-    /// User to use instead of the one set in context
+    /// User to use instead of the one set in context.
     pub user: Option<String>,
+
+    /// User to impersonate.
+    pub as_user: Option<String>,
+
+    /// Groups to impersonate.
+    pub as_groups: Option<Vec<String>>,
 
     /// Allow insecure connections (do not verify TLS certificate).
     pub allow_insecure: bool,
@@ -63,6 +69,8 @@ impl ClientOptions {
         Self {
             cluster: None,
             user: None,
+            as_user: None,
+            as_groups: None,
             allow_insecure,
         }
     }
@@ -264,6 +272,8 @@ async fn get_client_for_context(kubeconfig: Kubeconfig, context: &str, options: 
     };
 
     let mut config = Config::from_custom_kubeconfig(kubeconfig, &kubeconfig_options).await?;
+    config.auth_info.impersonate = options.as_user;
+    config.auth_info.impersonate_groups = options.as_groups;
     config.accept_invalid_certs = options.allow_insecure;
 
     let fixed_url = config.cluster_url.to_string().replace("0.0.0.0", "127.0.0.1");

--- a/b4n-kube/client.rs
+++ b/b4n-kube/client.rs
@@ -38,12 +38,26 @@ pub enum ClientError {
 }
 
 /// Options for the Kubernetes client.
+#[derive(Clone)]
 pub struct ClientOptions {
-    /// Fallback to the default context in case of an error.
-    pub fallback_to_default: bool,
+    /// Cluster to use instead of the one set in context.
+    pub cluster: Option<String>,
+
+    /// User to use instead of the one set in context
+    pub user: Option<String>,
 
     /// Allow insecure connections (do not verify TLS certificate).
     pub allow_insecure: bool,
+}
+
+impl ClientOptions {
+    pub fn new(allow_insecure: bool) -> Self {
+        Self {
+            cluster: None,
+            user: None,
+            allow_insecure,
+        }
+    }
 }
 
 /// Holds simplified context info.
@@ -67,7 +81,7 @@ pub struct KubernetesClient {
     client: Client,
 
     /// Kube config path.
-    kube_config_path: Option<String>,
+    kubeconfig_path: Option<String>,
 
     /// Context used by the kubernetes client.
     context: String,
@@ -78,27 +92,24 @@ pub struct KubernetesClient {
 
 impl KubernetesClient {
     /// Creates new [`KubernetesClient`] instance.
-    pub async fn new(
-        kube_config_path: Option<&str>,
-        kube_context: Option<&str>,
-        options: ClientOptions,
-    ) -> Result<Self, ClientError> {
-        let (kube_config, kube_config_path) = get_kube_config(kube_config_path).await?;
-        let (client, context) = get_client_fallback(kube_config, kube_context, options).await?;
+    pub async fn new(kubeconfig_path: Option<&str>, context: Option<&str>, options: ClientOptions) -> Result<Self, ClientError> {
+        let (kubeconfig, kubeconfig_path) = get_kubeconfig(kubeconfig_path).await?;
+        let (client, context) = get_client(kubeconfig, context, options).await?;
         let k8s_version = client.apiserver_version().await?.git_version.clone();
 
         Ok(Self {
             client,
-            kube_config_path,
+            kubeconfig_path,
             context,
             k8s_version,
         })
     }
 
-    /// Changes kube context for [`KubernetesClient`] which results in creating new kubernetes client.
+    /// Changes kube context for [`KubernetesClient`] which results in creating new kubernetes client.\
+    /// **Note** that it do not preserve `cluster` or `user` options.
     pub async fn change_context(&mut self, new_kube_context: Option<&str>, allow_insecure: bool) -> Result<(), ClientError> {
-        let (kube_config, _) = get_kube_config(self.kube_config_path.as_deref()).await?;
-        let (client, context) = get_client(kube_config, new_kube_context, allow_insecure).await?;
+        let (kubeconfig, _) = get_kubeconfig(self.kubeconfig_path.as_deref()).await?;
+        let (client, context) = get_client(kubeconfig, new_kube_context, ClientOptions::new(allow_insecure)).await?;
 
         self.k8s_version.clone_from(&client.apiserver_version().await?.git_version);
         self.context = context;
@@ -118,8 +129,8 @@ impl KubernetesClient {
     }
 
     /// Returns path to kube config used to create this client.
-    pub fn kube_config_path(&self) -> Option<&str> {
-        self.kube_config_path.as_deref()
+    pub fn kubeconfig_path(&self) -> Option<&str> {
+        self.kubeconfig_path.as_deref()
     }
 
     /// Returns kube context name for the currently held kubernetes client.
@@ -148,8 +159,8 @@ impl DerefMut for KubernetesClient {
 }
 
 /// Resolves `kubeconfig` path and checks if it exists.
-pub fn resolve_kube_config_path(kube_config_path: Option<&str>) -> Result<PathBuf, ClientError> {
-    let path = kube_config_path.map_or(
+pub fn resolve_kubeconfig_path(kubeconfig_path: Option<&str>) -> Result<PathBuf, ClientError> {
+    let path = kubeconfig_path.map_or(
         std::env::home_dir()
             .map(|h| h.join(".kube").join("config"))
             .ok_or(ClientError::HomeDirNotFound)?,
@@ -166,29 +177,29 @@ pub fn resolve_kube_config_path(kube_config_path: Option<&str>) -> Result<PathBu
 /// Returns matching context from the kube config for the provided one.\
 /// **Note** that it can `fallback_to_default` if the provided context is not found in kube config.
 pub async fn get_context(
-    kube_config_path: Option<&str>,
-    kube_context: Option<&str>,
+    kubeconfig_path: Option<&str>,
+    context: Option<&str>,
     fallback_to_default: bool,
 ) -> Result<(Option<ContextInfo>, Option<String>), ClientError> {
-    let (kube_config, kube_config_path) = get_kube_config(kube_config_path).await?;
-    if let Some(context_name) = kube_context
-        && let Some(context) = kube_config.contexts.iter().find(|c| c.name == context_name)
+    let (kubeconfig, kubeconfig_path) = get_kubeconfig(kubeconfig_path).await?;
+    if let Some(context_name) = context
+        && let Some(context) = kubeconfig.contexts.iter().find(|c| c.name == context_name)
     {
-        Ok((Some(context.into()), kube_config_path))
+        Ok((Some(context.into()), kubeconfig_path))
     } else if fallback_to_default
-        && let Some(context_name) = kube_config.current_context.as_deref()
-        && let Some(context) = kube_config.contexts.iter().find(|c| c.name == context_name)
+        && let Some(context_name) = kubeconfig.current_context.as_deref()
+        && let Some(context) = kubeconfig.contexts.iter().find(|c| c.name == context_name)
     {
-        Ok((Some(context.into()), kube_config_path))
+        Ok((Some(context.into()), kubeconfig_path))
     } else {
-        Ok((None, kube_config_path))
+        Ok((None, kubeconfig_path))
     }
 }
 
 /// Returns contexts from the kube config.
-pub async fn list_contexts(kube_config_path: Option<&str>) -> Result<Vec<NamedContext>, ClientError> {
-    let (kube_config, _) = get_kube_config(kube_config_path).await?;
-    Ok(kube_config.contexts)
+pub async fn list_contexts(kubeconfig_path: Option<&str>) -> Result<Vec<NamedContext>, ClientError> {
+    let (kubeconfig, _) = get_kubeconfig(kubeconfig_path).await?;
+    Ok(kubeconfig.contexts)
 }
 
 /// Gets dynamic api client for given `resource` and `namespace`.
@@ -208,53 +219,29 @@ pub fn get_dynamic_api(
     }
 }
 
-/// Creates kubernetes client and returns it together with used context.\
-/// If provided context is not valid it can try the default one.
-async fn get_client_fallback(
-    kube_config: Kubeconfig,
-    kube_context: Option<&str>,
-    options: ClientOptions,
-) -> Result<(Client, String), ClientError> {
-    if let Some(context) = get_context_internal(&kube_config, kube_context) {
-        Ok((
-            get_client_for_context(kube_config, &context, options.allow_insecure).await?,
-            context,
-        ))
-    } else if options.fallback_to_default {
-        tracing::error!("context '{:?}' not found, fallback to the default one", kube_context);
-        get_client(kube_config, None, options.allow_insecure).await
-    } else {
-        Err(ClientError::ContextNotFound)
-    }
-}
-
 /// Creates kubernetes client and returns it together with used context.
 async fn get_client(
-    kube_config: Kubeconfig,
-    kube_context: Option<&str>,
-    allow_insecure: bool,
+    kubeconfig: Kubeconfig,
+    context: Option<&str>,
+    options: ClientOptions,
 ) -> Result<(Client, String), ClientError> {
-    if let Some(context) = get_context_internal(&kube_config, kube_context) {
-        Ok((get_client_for_context(kube_config, &context, allow_insecure).await?, context))
+    if let Some(context) = get_context_internal(&kubeconfig, context) {
+        Ok((get_client_for_context(kubeconfig, &context, options).await?, context))
     } else {
         Err(ClientError::ContextNotFound)
     }
 }
 
 /// Creates kubernetes client for the provided [`Kubeconfig`] and context.
-async fn get_client_for_context(
-    kube_config: Kubeconfig,
-    kube_context: &str,
-    allow_insecure: bool,
-) -> Result<Client, ClientError> {
-    let kube_config_options = kube::config::KubeConfigOptions {
-        context: Some(String::from(kube_context)),
-        user: None,
-        cluster: None,
+async fn get_client_for_context(kubeconfig: Kubeconfig, context: &str, options: ClientOptions) -> Result<Client, ClientError> {
+    let kubeconfig_options = kube::config::KubeConfigOptions {
+        context: Some(String::from(context)),
+        user: options.user,
+        cluster: options.cluster,
     };
 
-    let mut config = Config::from_custom_kubeconfig(kube_config, &kube_config_options).await?;
-    config.accept_invalid_certs = allow_insecure;
+    let mut config = Config::from_custom_kubeconfig(kubeconfig, &kubeconfig_options).await?;
+    config.accept_invalid_certs = options.allow_insecure;
 
     let fixed_url = config.cluster_url.to_string().replace("0.0.0.0", "127.0.0.1");
     if let Ok(uri) = Uri::from_str(&fixed_url) {
@@ -265,27 +252,27 @@ async fn get_client_for_context(
 }
 
 /// Returns provided context (or default one if `None` specified).
-fn get_context_internal(kube_config: &Kubeconfig, kube_context: Option<&str>) -> Option<String> {
-    let Some(context) = kube_context else {
-        return kube_config.current_context.as_ref().map(String::from);
+fn get_context_internal(kubeconfig: &Kubeconfig, context: Option<&str>) -> Option<String> {
+    let Some(context) = context else {
+        return kubeconfig.current_context.as_ref().map(String::from);
     };
 
-    let context = kube_config.contexts.iter().find(|c| c.name == context);
+    let context = kubeconfig.contexts.iter().find(|c| c.name == context);
     context.map(|context| context.name.clone())
 }
 
 /// Returns kube config.
-async fn get_kube_config(kube_config_path: Option<&str>) -> Result<(Kubeconfig, Option<String>), ClientError> {
-    let path = resolve_kube_config_path(kube_config_path)?;
-    let path_result = if kube_config_path.is_some() {
+async fn get_kubeconfig(kubeconfig_path: Option<&str>) -> Result<(Kubeconfig, Option<String>), ClientError> {
+    let path = resolve_kubeconfig_path(kubeconfig_path)?;
+    let path_result = if kubeconfig_path.is_some() {
         Some(path.to_str().unwrap_or_default().to_string())
     } else {
         None
     };
     let mut file = File::open(path).await?;
 
-    let mut kube_config_str = String::new();
-    file.read_to_string(&mut kube_config_str).await?;
+    let mut kubeconfig_str = String::new();
+    file.read_to_string(&mut kubeconfig_str).await?;
 
-    Ok((Kubeconfig::from_yaml(&kube_config_str)?, path_result))
+    Ok((Kubeconfig::from_yaml(&kubeconfig_str)?, path_result))
 }

--- a/b4n-kube/client.rs
+++ b/b4n-kube/client.rs
@@ -32,6 +32,10 @@ pub enum ClientError {
     #[error("Kube user '{0}' not found in configuration.")]
     UserNotFound(String),
 
+    /// Certificate file not found.
+    #[error("Certificate path '{0}' not found.")]
+    CertificateNotFound(String),
+
     /// Failed to read kube configuration.
     #[error("cannot read kubeconfig: {0}")]
     IoError(#[from] std::io::Error),
@@ -45,7 +49,7 @@ pub enum ClientError {
     KubeError(#[from] kube::Error),
 
     /// Cannot join client creation task.
-    #[error("task join error: {0}")]
+    #[error("create client task join error: {0}")]
     TaskJoin(#[from] tokio::task::JoinError),
 }
 
@@ -190,6 +194,16 @@ pub fn resolve_kubeconfig_path(kubeconfig_path: Option<&str>) -> Result<PathBuf,
     }
 
     Ok(path::absolute(path)?)
+}
+
+/// Validates all provided certificate paths if they exists.
+pub fn validate_certificate_paths(paths: &[Option<&str>]) -> Result<(), ClientError> {
+    paths
+        .iter()
+        .flatten()
+        .map(std::path::Path::new)
+        .filter(|path| !path.exists() || !path.is_file())
+        .try_for_each(|path| Err(ClientError::CertificateNotFound(path.display().to_string())))
 }
 
 /// Validates provided configuration and returns matching context from the kubeconfig.\

--- a/b4n-tasks/commands/list_contexts.rs
+++ b/b4n-tasks/commands/list_contexts.rs
@@ -3,15 +3,15 @@ use tracing::error;
 
 use crate::commands::CommandResult;
 
-/// Command that reads kube config file and lists all contexts from it.
+/// Command that reads kubeconfig file and lists all contexts from it.
 pub struct ListKubeContextsCommand {
-    pub kube_config_path: Option<String>,
+    pub kubeconfig_path: Option<String>,
 }
 
 impl ListKubeContextsCommand {
-    /// Gets all contexts from the kube config file.
+    /// Gets all contexts from the kubeconfig file.
     pub async fn execute(&self) -> Option<CommandResult> {
-        match list_contexts(self.kube_config_path.as_deref()).await {
+        match list_contexts(self.kubeconfig_path.as_deref()).await {
             Ok(contexts) => Some(CommandResult::ContextsList(contexts)),
             Err(error) => {
                 error!("Cannot read contexts list: {}", error);

--- a/b4n-tasks/commands/mod.rs
+++ b/b4n-tasks/commands/mod.rs
@@ -10,7 +10,9 @@ pub use self::inject_container::{EphemeralContainerConfig, InjectContainerComman
 pub use self::list_contexts::ListKubeContextsCommand;
 pub use self::list_resource_ports::ListResourcePortsCommand;
 pub use self::list_themes::ListThemesCommand;
-pub use self::new_kubernetes_client::{KubernetesClientError, KubernetesClientResult, NewKubernetesClientCommand};
+pub use self::new_kubernetes_client::{
+    KubernetesClientError, KubernetesClientInfo, KubernetesClientResult, NewKubernetesClientCommand,
+};
 pub use self::run_plugin::{RunPluginCommand, RunPluginError, RunPluginOutput};
 pub use self::save_configuration::SaveConfigurationCommand;
 pub use self::save_content::SaveContentCommand;

--- a/b4n-tasks/commands/new_kubernetes_client.rs
+++ b/b4n-tasks/commands/new_kubernetes_client.rs
@@ -33,7 +33,7 @@ pub struct KubernetesClientResult {
 
 /// Command that creates new kubernetes client.
 pub struct NewKubernetesClientCommand {
-    pub kube_config_path: Option<String>,
+    pub kubeconfig_path: Option<String>,
     pub context: String,
     pub options: ClientOptions,
     pub kind: Kind,
@@ -43,14 +43,14 @@ pub struct NewKubernetesClientCommand {
 impl NewKubernetesClientCommand {
     /// Creates new [`NewKubernetesClientCommand`] instance.
     pub fn new(
-        kube_config_path: Option<String>,
+        kubeconfig_path: Option<String>,
         context: String,
         options: ClientOptions,
         kind: Kind,
         namespace: Namespace,
     ) -> Self {
         Self {
-            kube_config_path,
+            kubeconfig_path,
             context,
             options,
             kind,
@@ -60,7 +60,7 @@ impl NewKubernetesClientCommand {
 
     /// Creates new kubernetes client and returns it.
     pub async fn execute(self) -> Option<CommandResult> {
-        let client = KubernetesClient::new(self.kube_config_path.as_deref(), Some(&self.context), self.options).await;
+        let client = KubernetesClient::new(self.kubeconfig_path.as_deref(), Some(&self.context), self.options).await;
         let client = match client {
             Ok(client) => client,
             Err(err) => return Some(CommandResult::KubernetesClient(Err(err.into()))),

--- a/b4n-tasks/commands/new_kubernetes_client.rs
+++ b/b4n-tasks/commands/new_kubernetes_client.rs
@@ -23,9 +23,18 @@ pub enum KubernetesClientError {
     NamespaceFetchFailure,
 }
 
+/// Additional kubernetes client info.
+#[derive(Default)]
+pub struct KubernetesClientInfo {
+    pub is_custom_cluster: bool,
+    pub is_custom_user: bool,
+    pub is_impersonated: bool,
+}
+
 /// Result for the [`NewKubernetesClientCommand`].
 pub struct KubernetesClientResult {
     pub client: KubernetesClient,
+    pub client_info: KubernetesClientInfo,
     pub kind: Kind,
     pub namespace: Namespace,
     pub discovery: DiscoveryList,
@@ -60,6 +69,10 @@ impl NewKubernetesClientCommand {
 
     /// Creates new kubernetes client and returns it.
     pub async fn execute(self) -> Option<CommandResult> {
+        let is_impersonated = self.options.as_user.is_some();
+        let is_custom_cluster = self.options.cluster.is_some();
+        let is_custom_user = self.options.user.is_some();
+
         let client = KubernetesClient::new(self.kubeconfig_path.as_deref(), Some(&self.context), self.options).await;
         let client = match client {
             Ok(client) => client,
@@ -111,6 +124,11 @@ impl NewKubernetesClientCommand {
             kind,
             namespace,
             discovery,
+            client_info: KubernetesClientInfo {
+                is_custom_cluster,
+                is_custom_user,
+                is_impersonated,
+            },
         })))
     }
 }

--- a/b4n-tasks/commands/new_kubernetes_client.rs
+++ b/b4n-tasks/commands/new_kubernetes_client.rs
@@ -35,9 +35,9 @@ pub struct KubernetesClientResult {
 pub struct NewKubernetesClientCommand {
     pub kube_config_path: Option<String>,
     pub context: String,
+    pub options: ClientOptions,
     pub kind: Kind,
     pub namespace: Namespace,
-    pub allow_insecure: bool,
 }
 
 impl NewKubernetesClientCommand {
@@ -45,30 +45,22 @@ impl NewKubernetesClientCommand {
     pub fn new(
         kube_config_path: Option<String>,
         context: String,
+        options: ClientOptions,
         kind: Kind,
         namespace: Namespace,
-        allow_insecure: bool,
     ) -> Self {
         Self {
             kube_config_path,
             context,
+            options,
             kind,
             namespace,
-            allow_insecure,
         }
     }
 
     /// Creates new kubernetes client and returns it.
     pub async fn execute(self) -> Option<CommandResult> {
-        let client = KubernetesClient::new(
-            self.kube_config_path.as_deref(),
-            Some(&self.context),
-            ClientOptions {
-                fallback_to_default: false,
-                allow_insecure: self.allow_insecure,
-            },
-        )
-        .await;
+        let client = KubernetesClient::new(self.kube_config_path.as_deref(), Some(&self.context), self.options).await;
         let client = match client {
             Ok(client) => client,
             Err(err) => return Some(CommandResult::KubernetesClient(Err(err.into()))),

--- a/b4n/cli.rs
+++ b/b4n/cli.rs
@@ -42,18 +42,18 @@ pub struct Args {
     pub as_group: Vec<String>,
 
     /// Path to a client certificate file for TLS authentication.
-    #[arg(long)]
+    #[arg(long, requires = "client_key")]
     pub client_cert: Option<String>,
 
     /// Path to a client key file for TLS authentication.
-    #[arg(long)]
+    #[arg(long, requires = "client_cert")]
     pub client_key: Option<String>,
 
-    /// Path to a cert file with the certificate authority to use.
+    /// Path to a CA file for server TLS verification.
     #[arg(long = "ca")]
     pub certificate_authority: Option<String>,
 
-    /// Skip TLS certificate verification (unsafe).
+    /// Skip server TLS certificate verification (unsafe).
     #[arg(long)]
     pub insecure: bool,
 

--- a/b4n/cli.rs
+++ b/b4n/cli.rs
@@ -13,11 +13,11 @@ pub struct Args {
     #[arg(long, short)]
     pub namespace: Option<String>,
 
-    /// Start with cluster-wide view (all namespaces).
+    /// Show resources across all namespaces.
     #[arg(long, short = 'A')]
     pub all_namespaces: bool,
 
-    /// Path to the kubeconfig file (defaults to $HOME/.kube/config).
+    /// Path to the kubeconfig file (defaults to $KUBECONFIG or ~/.kube/config).
     #[arg(long, env = "KUBECONFIG")]
     pub kube_config: Option<String>,
 
@@ -33,7 +33,15 @@ pub struct Args {
     #[arg(long)]
     pub user: Option<String>,
 
-    /// Skip TLS certificate verification (insecure).
+    /// Username to impersonate during the session.
+    #[arg(long = "as")]
+    pub as_user: Option<String>,
+
+    /// Group to impersonate during the session.
+    #[arg(long)]
+    pub as_group: Vec<String>,
+
+    /// Skip TLS certificate verification (unsafe).
     #[arg(long)]
     pub insecure: bool,
 
@@ -46,7 +54,8 @@ impl Args {
     /// Returns context or `last_used` if context is `None` and cluster or user is not provided.
     pub fn context<'a>(&'a self, last_used: Option<&'a str>) -> Option<&'a str> {
         self.context.as_deref().or_else(|| {
-            let allow_last_used = self.cluster.is_none() && self.user.is_none();
+            let allow_last_used =
+                self.cluster.is_none() && self.user.is_none() && self.as_user.is_none() && self.as_group.is_empty();
             if allow_last_used { last_used } else { None }
         })
     }

--- a/b4n/cli.rs
+++ b/b4n/cli.rs
@@ -43,7 +43,7 @@ pub struct Args {
 }
 
 impl Args {
-    /// Returns context or `last_used` from the history if context is `None`.
+    /// Returns context or `last_used` if context is `None` and cluster or user is not provided.
     pub fn context<'a>(&'a self, last_used: Option<&'a str>) -> Option<&'a str> {
         self.context.as_deref().or_else(|| {
             let allow_last_used = self.cluster.is_none() && self.user.is_none();

--- a/b4n/cli.rs
+++ b/b4n/cli.rs
@@ -1,4 +1,4 @@
-use b4n_kube::ALL_NAMESPACES;
+use b4n_kube::{ALL_NAMESPACES, client::ClientOptions};
 use clap::Parser;
 
 /// b4n is an interactive TUI for managing Kubernetes clusters.
@@ -41,6 +41,18 @@ pub struct Args {
     #[arg(long, requires = "as_user")]
     pub as_group: Vec<String>,
 
+    /// Path to a client certificate file for TLS authentication.
+    #[arg(long)]
+    pub client_cert: Option<String>,
+
+    /// Path to a client key file for TLS authentication.
+    #[arg(long)]
+    pub client_key: Option<String>,
+
+    /// Path to a cert file with the certificate authority to use.
+    #[arg(long = "ca")]
+    pub certificate_authority: Option<String>,
+
     /// Skip TLS certificate verification (unsafe).
     #[arg(long)]
     pub insecure: bool,
@@ -51,7 +63,9 @@ pub struct Args {
 }
 
 impl Args {
-    /// Returns context or `last_used` if context is `None` and cluster or user is not provided.
+    /// Returns context name or `last_used` if:
+    /// - context is `None`,
+    /// - cluster, user or impersonation is not provided.
     pub fn context<'a>(&'a self, last_used: Option<&'a str>) -> Option<&'a str> {
         self.context.as_deref().or_else(|| {
             let allow_last_used =
@@ -85,6 +99,21 @@ impl Args {
             self.resource.as_deref()
         } else {
             default
+        }
+    }
+}
+
+impl From<&Args> for ClientOptions {
+    fn from(value: &Args) -> Self {
+        Self {
+            cluster: value.cluster.clone(),
+            user: value.user.clone(),
+            as_user: value.as_user.clone(),
+            as_groups: (!value.as_group.is_empty()).then(|| value.as_group.clone()),
+            client_cert: value.client_cert.clone(),
+            client_key: value.client_key.clone(),
+            certificate_authority: value.certificate_authority.clone(),
+            allow_insecure: value.insecure,
         }
     }
 }

--- a/b4n/cli.rs
+++ b/b4n/cli.rs
@@ -38,7 +38,7 @@ pub struct Args {
     pub as_user: Option<String>,
 
     /// Group to impersonate during the session.
-    #[arg(long)]
+    #[arg(long, requires = "as_user")]
     pub as_group: Vec<String>,
 
     /// Skip TLS certificate verification (unsafe).

--- a/b4n/cli.rs
+++ b/b4n/cli.rs
@@ -5,14 +5,6 @@ use clap::Parser;
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
 pub struct Args {
-    /// Path to the kubeconfig file (defaults to $HOME/.kube/config).
-    #[arg(long, env = "KUBECONFIG")]
-    pub kube_config: Option<String>,
-
-    /// Context to use from the kubeconfig file.
-    #[arg(long)]
-    pub context: Option<String>,
-
     /// Kubernetes resource kind to show (e.g. pods, deployments, services).
     #[arg()]
     pub resource: Option<String>,
@@ -25,6 +17,22 @@ pub struct Args {
     #[arg(long, short = 'A')]
     pub all_namespaces: bool,
 
+    /// Path to the kubeconfig file (defaults to $HOME/.kube/config).
+    #[arg(long, env = "KUBECONFIG")]
+    pub kube_config: Option<String>,
+
+    /// Context to use from the kubeconfig file.
+    #[arg(long)]
+    pub context: Option<String>,
+
+    /// Cluster to use from the kubeconfig file.
+    #[arg(long)]
+    pub cluster: Option<String>,
+
+    /// User to use from the kubeconfig file.
+    #[arg(long)]
+    pub user: Option<String>,
+
     /// Skip TLS certificate verification (insecure).
     #[arg(long)]
     pub insecure: bool,
@@ -35,13 +43,12 @@ pub struct Args {
 }
 
 impl Args {
-    /// Returns context or default if context is `None`.
-    pub fn context<'a>(&'a self, default: Option<&'a str>) -> Option<&'a str> {
-        if self.context.is_some() {
-            self.context.as_deref()
-        } else {
-            default
-        }
+    /// Returns context or `last_used` from the history if context is `None`.
+    pub fn context<'a>(&'a self, last_used: Option<&'a str>) -> Option<&'a str> {
+        self.context.as_deref().or_else(|| {
+            let allow_last_used = self.cluster.is_none() && self.user.is_none();
+            if allow_last_used { last_used } else { None }
+        })
     }
 
     /// Returns the namespace option respecting `--all-namespaces` switch.

--- a/b4n/core/app.rs
+++ b/b4n/core/app.rs
@@ -438,10 +438,10 @@ impl App {
 
     /// Runs command to list kube contexts from the current config.
     fn list_kube_contexts(&mut self) {
-        let kube_config_path = self.data.borrow().history.kube_config_path().map(String::from);
+        let kubeconfig_path = self.data.borrow().history.kubeconfig_path().map(String::from);
         self.worker
             .borrow_mut()
-            .run_command(Command::ListKubeContexts(ListKubeContextsCommand { kube_config_path }));
+            .run_command(Command::ListKubeContexts(ListKubeContextsCommand { kubeconfig_path }));
     }
 
     /// Runs command to list themes from the themes directory.

--- a/b4n/core/app.rs
+++ b/b4n/core/app.rs
@@ -3,6 +3,7 @@ use b4n_common::{DEFAULT_ERROR_DURATION, DEFAULT_MESSAGE_DURATION, IconKind};
 use b4n_config::keys::{KeyBindings, KeyCommand};
 use b4n_config::themes::Theme;
 use b4n_config::{Config, ConfigError, ConfigWatcher, History, PluginsWatcher, SyntaxData};
+use b4n_kube::client::ClientOptions;
 use b4n_kube::{Kind, NAMESPACES, Namespace, ResourceRef};
 use b4n_tasks::commands::{
     Command, CommandResult, KubernetesClientError, KubernetesClientResult, ListKubeContextsCommand, ListThemesCommand,
@@ -15,6 +16,7 @@ use std::net::{IpAddr, SocketAddr};
 use std::rc::Rc;
 use tokio::runtime::Handle;
 
+use crate::cli::Args;
 use crate::core::{
     AppData, BgWorker, BgWorkerError, KubernetesClientManager, SharedAppData, SharedAppDataExt, SharedBgWorker, ViewsManager,
 };
@@ -49,7 +51,7 @@ pub struct App {
 
 impl App {
     /// Creates new [`App`] instance.
-    pub fn new(runtime: Handle, config: Config, history: History, theme: Theme, allow_insecure: bool) -> Result<Self> {
+    pub fn new(runtime: Handle, config: Config, history: History, theme: Theme, args: &Args) -> Result<Self> {
         let is_mouse_enabled = config.mouse;
         let theme_path = config.theme_path();
         let syntax_data = SyntaxData::new(&theme);
@@ -61,8 +63,13 @@ impl App {
             syntax_data,
         )));
         let resources = ResourcesView::new(Rc::clone(&data), Rc::clone(&worker), footer.get_transmitter());
+        let options = ClientOptions {
+            cluster: args.cluster.as_deref().map(String::from),
+            user: args.user.as_deref().map(String::from),
+            allow_insecure: args.insecure,
+        };
         let client_manager =
-            KubernetesClientManager::new(Rc::clone(&data), Rc::clone(&worker), footer.get_transmitter(), allow_insecure);
+            KubernetesClientManager::new(Rc::clone(&data), Rc::clone(&worker), footer.get_transmitter(), options);
         let mut views_manager = ViewsManager::new(Rc::clone(&data), Rc::clone(&worker), resources, footer);
         views_manager.set_message_history_hint();
 
@@ -159,7 +166,7 @@ impl App {
             {
                 let theme = &self.data.borrow().config.theme;
                 self.show_theme_error(format!("Error loading '{theme}' theme: {error}"));
-            }
+            },
             _ => (),
         }
 

--- a/b4n/core/app.rs
+++ b/b4n/core/app.rs
@@ -64,8 +64,10 @@ impl App {
         )));
         let resources = ResourcesView::new(Rc::clone(&data), Rc::clone(&worker), footer.get_transmitter());
         let options = ClientOptions {
-            cluster: args.cluster.as_deref().map(String::from),
-            user: args.user.as_deref().map(String::from),
+            cluster: args.cluster.clone(),
+            user: args.user.clone(),
+            as_user: args.as_user.clone(),
+            as_groups: (!args.as_group.is_empty()).then(|| args.as_group.clone()),
             allow_insecure: args.insecure,
         };
         let client_manager =

--- a/b4n/core/app.rs
+++ b/b4n/core/app.rs
@@ -16,10 +16,8 @@ use std::net::{IpAddr, SocketAddr};
 use std::rc::Rc;
 use tokio::runtime::Handle;
 
-use crate::cli::Args;
-use crate::core::{
-    AppData, BgWorker, BgWorkerError, KubernetesClientManager, SharedAppData, SharedAppDataExt, SharedBgWorker, ViewsManager,
-};
+use crate::core::managers::{KubernetesClientManager, ViewsManager};
+use crate::core::{AppData, BgWorker, BgWorkerError, SharedAppData, SharedAppDataExt, SharedBgWorker};
 use crate::ui::views::ResourcesView;
 
 /// Application execution flow.
@@ -51,7 +49,7 @@ pub struct App {
 
 impl App {
     /// Creates new [`App`] instance.
-    pub fn new(runtime: Handle, config: Config, history: History, theme: Theme, args: &Args) -> Result<Self> {
+    pub fn new(runtime: Handle, config: Config, history: History, theme: Theme, options: ClientOptions) -> Result<Self> {
         let is_mouse_enabled = config.mouse;
         let theme_path = config.theme_path();
         let syntax_data = SyntaxData::new(&theme);
@@ -63,13 +61,6 @@ impl App {
             syntax_data,
         )));
         let resources = ResourcesView::new(Rc::clone(&data), Rc::clone(&worker), footer.get_transmitter());
-        let options = ClientOptions {
-            cluster: args.cluster.clone(),
-            user: args.user.clone(),
-            as_user: args.as_user.clone(),
-            as_groups: (!args.as_group.is_empty()).then(|| args.as_group.clone()),
-            allow_insecure: args.insecure,
-        };
         let client_manager =
             KubernetesClientManager::new(Rc::clone(&data), Rc::clone(&worker), footer.get_transmitter(), options);
         let mut views_manager = ViewsManager::new(Rc::clone(&data), Rc::clone(&worker), resources, footer);

--- a/b4n/core/app.rs
+++ b/b4n/core/app.rs
@@ -450,6 +450,7 @@ impl App {
             let resource = ResourceRef::new(result.kind.clone(), result.namespace.clone());
 
             let scope = self.worker.borrow_mut().start(result.client, result.discovery, resource);
+            self.data.borrow_mut().client_info = result.client_info;
             if let Ok(scope) = scope {
                 self.views_manager
                     .process_context_change(context, result.namespace.clone(), version, scope.clone());

--- a/b4n/core/data.rs
+++ b/b4n/core/data.rs
@@ -4,6 +4,7 @@ use b4n_config::keys::{KeyBindings, KeyCombination, KeyCommand};
 use b4n_config::{Config, History, themes::Theme};
 use b4n_config::{PluginInput, PluginRef, Plugins};
 use b4n_kube::{CONTAINERS, InitData, Kind, Namespace, ResourceRef};
+use b4n_tasks::commands::KubernetesClientInfo;
 use b4n_tui::widgets::SharedClipboard;
 use b4n_tui::{ToSelectData, TuiEvent};
 use kube::discovery::Scope;
@@ -150,6 +151,8 @@ pub struct AppData {
     pub is_pinned: bool,
 
     pub is_mouse_enabled: bool,
+
+    pub client_info: KubernetesClientInfo,
 
     /// Holds all discovered kinds.
     pub kinds: Option<Vec<KindItem>>,

--- a/b4n/core/managers/client.rs
+++ b/b4n/core/managers/client.rs
@@ -1,5 +1,5 @@
 use b4n_common::{DEFAULT_ERROR_DURATION, DEFAULT_MESSAGE_DURATION, NotificationSink, StateChangeTracker};
-use b4n_kube::{Kind, Namespace};
+use b4n_kube::{Kind, Namespace, client::ClientOptions};
 use b4n_tasks::commands::{Command, KubernetesClientError, KubernetesClientResult, NewKubernetesClientCommand};
 use std::time::Instant;
 use tracing::warn;
@@ -11,6 +11,7 @@ struct RequestInfo {
     request_time: Instant,
     request_id: Option<String>,
     context: String,
+    options: ClientOptions,
     kind: Kind,
     namespace: Namespace,
 }
@@ -34,31 +35,36 @@ pub struct KubernetesClientManager {
     request: Option<RequestInfo>,
     footer_tx: NotificationSink,
     connection_state: StateChangeTracker<bool>,
-    allow_insecure: bool,
+    options: ClientOptions,
 }
 
 impl KubernetesClientManager {
     /// Creates new [`KubernetesClientManager`] instance.
-    pub fn new(app_data: SharedAppData, worker: SharedBgWorker, footer_tx: NotificationSink, allow_insecure: bool) -> Self {
+    pub fn new(app_data: SharedAppData, worker: SharedBgWorker, footer_tx: NotificationSink, options: ClientOptions) -> Self {
         Self {
             app_data,
             worker,
             request: None,
             footer_tx,
             connection_state: StateChangeTracker::new(Some(false)),
-            allow_insecure,
+            options,
         }
     }
 
-    /// Sends command to create new Kubernetes client to the background executor.
+    /// Sends command to create new Kubernetes client to the background executor.\
+    /// **Note** that when the client is requested for the first time it uses `self.options` that are then replaced
+    /// with the default options.
     pub fn request_new_client(&mut self, context: String, kind: Kind, namespace: Namespace) {
         if let Some(connecting) = &self.request {
             self.worker.borrow_mut().cancel_command(connecting.request_id.as_deref());
         }
 
+        let new_options = ClientOptions::new(self.options.allow_insecure);
+        let options = std::mem::replace(&mut self.options, new_options);
         let msg = format!("Requested kubernetes client for '{context}'");
+
+        self.request = Some(self.new_kubernetes_client(context, options, kind, namespace));
         self.footer_tx.show_info(msg, DEFAULT_MESSAGE_DURATION);
-        self.request = Some(self.new_kubernetes_client(context, kind, namespace));
     }
 
     /// Clears the current Kubernetes request data.\
@@ -89,7 +95,8 @@ impl KubernetesClientManager {
             let msg = format!("Request is overdue, resending for '{}'", connecting.context);
             warn!("{}", msg);
             self.footer_tx.show_error(msg, DEFAULT_ERROR_DURATION);
-            self.request = Some(self.new_kubernetes_client(connecting.context, connecting.kind, connecting.namespace));
+            self.request =
+                Some(self.new_kubernetes_client(connecting.context, connecting.options, connecting.kind, connecting.namespace));
         }
     }
 
@@ -139,14 +146,20 @@ impl KubernetesClientManager {
     }
 
     /// Sends command to create new Kubernetes client to the background executor.
-    fn new_kubernetes_client(&mut self, context: String, kind: Kind, namespace: Namespace) -> RequestInfo {
+    fn new_kubernetes_client(
+        &mut self,
+        context: String,
+        options: ClientOptions,
+        kind: Kind,
+        namespace: Namespace,
+    ) -> RequestInfo {
         let kube_config_path = self.app_data.borrow().history.kube_config_path().map(String::from);
         let cmd = NewKubernetesClientCommand::new(
             kube_config_path,
             context.clone(),
+            options.clone(),
             kind.clone(),
             namespace.clone(),
-            self.allow_insecure,
         );
 
         RequestInfo {
@@ -157,6 +170,7 @@ impl KubernetesClientManager {
             ),
             request_time: Instant::now(),
             context,
+            options,
             kind,
             namespace,
         }

--- a/b4n/core/managers/client.rs
+++ b/b4n/core/managers/client.rs
@@ -153,9 +153,9 @@ impl KubernetesClientManager {
         kind: Kind,
         namespace: Namespace,
     ) -> RequestInfo {
-        let kube_config_path = self.app_data.borrow().history.kube_config_path().map(String::from);
+        let kubeconfig_path = self.app_data.borrow().history.kubeconfig_path().map(String::from);
         let cmd = NewKubernetesClientCommand::new(
-            kube_config_path,
+            kubeconfig_path,
             context.clone(),
             options.clone(),
             kind.clone(),

--- a/b4n/core/managers/client.rs
+++ b/b4n/core/managers/client.rs
@@ -26,6 +26,11 @@ impl RequestInfo {
     pub fn is_overdue(&self) -> bool {
         self.request_id.is_none() && self.request_time.elapsed().as_secs() > 30
     }
+
+    /// Returns `true` if options for this request have overrides.
+    pub fn has_overrides(&self) -> bool {
+        self.options.has_overrides()
+    }
 }
 
 /// Kubernetes client manager.
@@ -109,8 +114,8 @@ impl KubernetesClientManager {
         if self.request_match(command_id) {
             match result {
                 Ok(result) => {
-                    self.request = None;
-                    let msg = format!("Connected to '{}'", result.client.context());
+                    let request = self.request.take();
+                    let msg = get_connected_message(request.as_ref(), result.client.context());
                     self.footer_tx.show_info(msg, DEFAULT_MESSAGE_DURATION);
                     Some(result)
                 },
@@ -174,5 +179,15 @@ impl KubernetesClientManager {
             kind,
             namespace,
         }
+    }
+}
+
+fn get_connected_message(request: Option<&RequestInfo>, context: &str) -> String {
+    if let Some(request) = request
+        && request.has_overrides()
+    {
+        format!("Connected to '{}' ({})", context, request.options)
+    } else {
+        format!("Connected to '{context}'")
     }
 }

--- a/b4n/main.rs
+++ b/b4n/main.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use b4n_config::{Config, ConfigError, History};
 use b4n_kube::PODS;
-use b4n_kube::client::{get_context, resolve_kubeconfig_path};
+use b4n_kube::client::{resolve_kubeconfig_path, validate_and_resolve_context};
 use clap::Parser;
 use core::{App, ExecutionFlow};
 use std::thread::sleep;
@@ -44,17 +44,13 @@ fn run_application(args: &cli::Args) -> Result<()> {
     let rt = Builder::new_multi_thread().enable_all().build()?;
 
     let mut history = rt.block_on(History::load_or_create())?;
-    let (context, kube_config_path) = rt.block_on(get_context(
+    let (context, kube_config_path) = rt.block_on(validate_and_resolve_context(
         args.kube_config.as_deref(),
         args.context(history.current_context()),
+        args.cluster.as_deref(),
+        args.user.as_deref(),
         args.context.is_none(),
     ))?;
-    let Some(context) = context else {
-        return Err(anyhow::anyhow!(format!(
-            "Kube context '{}' not found in configuration.",
-            args.context(history.current_context()).unwrap_or("default")
-        )));
-    };
     history.set_kube_config_path(kube_config_path);
 
     let kind = args.kind(history.get_kind(&context.name)).unwrap_or(PODS).into();

--- a/b4n/main.rs
+++ b/b4n/main.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use b4n_config::{Config, ConfigError, History};
 use b4n_kube::PODS;
-use b4n_kube::client::{resolve_kubeconfig_path, validate_and_resolve_context};
+use b4n_kube::client::{resolve_kubeconfig_path, validate_and_resolve_context, validate_certificate_paths};
 use clap::Parser;
 use core::{App, ExecutionFlow};
 use std::thread::sleep;
@@ -52,6 +52,12 @@ fn run_application(args: &cli::Args) -> Result<()> {
         args.context.is_none(),
     ))?;
     history.set_kubeconfig_path(kubeconfig_path);
+
+    validate_certificate_paths(&[
+        args.client_cert.as_deref(),
+        args.client_key.as_deref(),
+        args.certificate_authority.as_deref(),
+    ])?;
 
     let kind = args.kind(history.get_kind(&context.name)).unwrap_or(PODS).into();
     let namespace = history.get_namespace(&context.name).or(context.namespace.as_deref());

--- a/b4n/main.rs
+++ b/b4n/main.rs
@@ -44,14 +44,14 @@ fn run_application(args: &cli::Args) -> Result<()> {
     let rt = Builder::new_multi_thread().enable_all().build()?;
 
     let mut history = rt.block_on(History::load_or_create())?;
-    let (context, kube_config_path) = rt.block_on(validate_and_resolve_context(
+    let (context, kubeconfig_path) = rt.block_on(validate_and_resolve_context(
         args.kube_config.as_deref(),
         args.context(history.current_context()),
         args.cluster.as_deref(),
         args.user.as_deref(),
         args.context.is_none(),
     ))?;
-    history.set_kube_config_path(kube_config_path);
+    history.set_kubeconfig_path(kubeconfig_path);
 
     let kind = args.kind(history.get_kind(&context.name)).unwrap_or(PODS).into();
     let namespace = history.get_namespace(&context.name).or(context.namespace.as_deref());

--- a/b4n/main.rs
+++ b/b4n/main.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use b4n_config::{Config, ConfigError, History};
 use b4n_kube::PODS;
-use b4n_kube::client::{get_context, resolve_kube_config_path};
+use b4n_kube::client::{get_context, resolve_kubeconfig_path};
 use clap::Parser;
 use core::{App, ExecutionFlow};
 use std::thread::sleep;
@@ -18,7 +18,7 @@ fn main() -> Result<()> {
     let args = cli::Args::parse();
     if args.show_dirs {
         Config::init_dirs(false)?;
-        Config::print_dirs(resolve_kube_config_path(args.kube_config.as_deref()).ok());
+        Config::print_dirs(resolve_kubeconfig_path(args.kube_config.as_deref()).ok());
         return Ok(());
     }
 
@@ -64,7 +64,7 @@ fn run_application(args: &cli::Args) -> Result<()> {
     let (config, config_error) = rt.block_on(Config::load_or_create());
     let (theme, theme_error) = rt.block_on(config.load_theme());
 
-    let mut app = App::new(rt.handle().clone(), config, history, theme, args.insecure)?;
+    let mut app = App::new(rt.handle().clone(), config, history, theme, args)?;
     app.start(context.name, kind, namespace)?;
 
     if let Some(error) = config_error

--- a/b4n/main.rs
+++ b/b4n/main.rs
@@ -60,7 +60,7 @@ fn run_application(args: &cli::Args) -> Result<()> {
     let (config, config_error) = rt.block_on(Config::load_or_create());
     let (theme, theme_error) = rt.block_on(config.load_theme());
 
-    let mut app = App::new(rt.handle().clone(), config, history, theme, args)?;
+    let mut app = App::new(rt.handle().clone(), config, history, theme, args.into())?;
     app.start(context.name, kind, namespace)?;
 
     if let Some(error) = config_error

--- a/b4n/ui/presentation/utils.rs
+++ b/b4n/ui/presentation/utils.rs
@@ -40,7 +40,7 @@ pub fn get_left_breadcrumbs<'a>(
 
     let mut path = vec![
         Span::styled("", Style::new().fg(context.bg).bg(app_data.theme.colors.text.bg)),
-        Span::styled(format!(" {} ", data.context), &context),
+        Span::styled(get_context_display(app_data), &context),
     ];
 
     let namespace = namespace.unwrap_or_else(|| get_breadcrumbs_namespace(scope, data, kind));
@@ -101,6 +101,28 @@ fn get_context_color(app_data: &AppData) -> TextColors {
         .as_ref()
         .and_then(|contexts| contexts.get(&app_data.current.context))
         .map_or(app_data.theme.colors.header.context, |f| *f)
+}
+
+fn get_context_display(app_data: &AppData) -> String {
+    let mut result = String::with_capacity(app_data.current.context.len() + 5);
+    result.push(' ');
+    result.push_str(&app_data.current.context);
+    result.push(' ');
+
+    let mut has_custom = false;
+    if app_data.client_info.is_custom_cluster || app_data.client_info.is_custom_user {
+        result.push('');
+        has_custom = true;
+    }
+    if app_data.client_info.is_impersonated {
+        result.push('󰗹');
+        has_custom = true;
+    }
+    if has_custom {
+        result.push(' ');
+    }
+
+    result
 }
 
 #[derive(Default)]

--- a/b4n/ui/views/resources/dialogs.rs
+++ b/b4n/ui/views/resources/dialogs.rs
@@ -151,7 +151,7 @@ pub fn build_plugin_context(
 
     let app_data = app_data.borrow();
     PluginContext {
-        kubeconfig: app_data.history.kube_config_path().map(String::from).unwrap_or_default(),
+        kubeconfig: app_data.history.kubeconfig_path().map(String::from).unwrap_or_default(),
         context: app_data.current.context.clone(),
         kind: app_data.current.resource.kind.clone(),
         namespace: app_data.current.namespace.clone(),


### PR DESCRIPTION
Added:

- `--cluster` and `--user` options to override context configuration
- `--as` and `--as-group` options to impersonate a user during the session
- `--client-cert`, `--client-key`, and `--ca` options for custom TLS authentication