### PR TITLE
Move selected lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Features
 
-- `ALT+↑` and `ALT+↓` now works with selections
+- `Alt+↑` and `Alt+↓` now works with selections
+- remember selection for undo and redo actions in edit mode
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## WIP
+
+### Features
+
+- `ALT+↑` and `ALT+↓` now works with selections
+
+### Bug Fixes
+
+- fix undo for whole line selection removal when the last line is deleted
+
 ## 0.5.7 - 2026-08-27
 
 ### Features

--- a/b4n/ui/presentation/content/edit.rs
+++ b/b4n/ui/presentation/content/edit.rs
@@ -261,26 +261,34 @@ impl EditContext {
             return None;
         }
 
-        match selection.as_ref().map(Selection::sorted) {
-            Some(sorted) => {
-                let line_count = i32::try_from(sorted.1.y - sorted.0.y + 1).unwrap_or_default();
-                if move_up && sorted.0.y > 0 {
-                    content.move_line(sorted.0.y - 1, line_count);
-                    return Some((Some(Some(self.cursor.x)), Some(self.cursor.y.saturating_sub(1))));
-                } else if move_down && sorted.1.y + 1 < content.len() {
-                    content.move_line(sorted.1.y + 1, -line_count);
-                    return Some((Some(Some(self.cursor.x)), Some(self.cursor.y + 1)));
+        if let Some(selection) = &selection {
+            let mut cursor = selection.end;
+            if cursor.x >= content.line_size(cursor.y) {
+                cursor.x = 0;
+                cursor.y += 1;
+            }
+
+            let sorted = selection.sorted();
+            let line_count = i32::try_from(sorted.1.y - sorted.0.y + 1).unwrap_or_default();
+            if move_up && sorted.0.y > 0 {
+                content.move_line(sorted.0.y - 1, line_count);
+                return Some((Some(Some(cursor.x)), Some(cursor.y.saturating_sub(1))));
+            } else if move_down && sorted.1.y + 1 < content.len() {
+                content.move_line(sorted.1.y + 1, -line_count);
+                if cursor.y + 1 < content.len() {
+                    return Some((Some(Some(cursor.x)), Some(cursor.y + 1)));
+                } else {
+                    return Some((Some(Some(content.line_size(cursor.y))), Some(cursor.y)));
                 }
-            },
-            None => {
-                if move_up && self.cursor.y > 0 {
-                    content.swap_lines(self.cursor.y - 1, self.cursor.y);
-                    return Some((Some(Some(self.cursor.x)), Some(self.cursor.y.saturating_sub(1))));
-                } else if move_down && self.cursor.y + 1 < content.len() {
-                    content.swap_lines(self.cursor.y, self.cursor.y + 1);
-                    return Some((Some(Some(self.cursor.x)), Some(self.cursor.y + 1)));
-                }
-            },
+            }
+        } else {
+            if move_up && self.cursor.y > 0 {
+                content.swap_lines(self.cursor.y - 1, self.cursor.y);
+                return Some((Some(Some(self.cursor.x)), Some(self.cursor.y.saturating_sub(1))));
+            } else if move_down && self.cursor.y + 1 < content.len() {
+                content.swap_lines(self.cursor.y, self.cursor.y + 1);
+                return Some((Some(Some(self.cursor.x)), Some(self.cursor.y + 1)));
+            }
         }
 
         Some((None, None))

--- a/b4n/ui/presentation/content/edit.rs
+++ b/b4n/ui/presentation/content/edit.rs
@@ -146,15 +146,7 @@ impl EditContext {
         selection: Option<Selection>,
         area: Rect,
     ) -> NewCursorPosition {
-        if selection.is_none() {
-            if self.app_data.has_key_binding(key, KeyCommand::EditMoveUp) && self.cursor.y > 0 {
-                content.swap_lines(self.cursor.y.saturating_sub(1), self.cursor.y);
-            }
-
-            if self.app_data.has_key_binding(key, KeyCommand::EditMoveDown) && self.cursor.y + 1 < content.len() {
-                content.swap_lines(self.cursor.y, self.cursor.y + 1);
-            }
-        }
+        self.handle_lines_move(key, content, &selection);
 
         let is_cut = self.app_data.has_key_binding(key, KeyCommand::EditCut);
         if (is_hiding_selection_key(key) || is_cut)
@@ -252,6 +244,33 @@ impl EditContext {
         }
 
         (None, None)
+    }
+
+    fn handle_lines_move<T: Content>(&mut self, key: &KeyCombination, content: &mut T, selection: &Option<Selection>) {
+        let move_up = self.app_data.has_key_binding(key, KeyCommand::EditMoveUp);
+        let move_down = self.app_data.has_key_binding(key, KeyCommand::EditMoveDown);
+
+        if !move_up && !move_down {
+            return;
+        }
+
+        match selection.as_ref().map(Selection::sorted) {
+            Some(sorted) => {
+                let line_count = i32::try_from(sorted.1.y - sorted.0.y + 1).unwrap_or_default();
+                if move_up && sorted.0.y > 0 {
+                    content.move_line(sorted.0.y - 1, line_count);
+                } else if move_down && sorted.1.y + 1 < content.len() {
+                    content.move_line(sorted.1.y + 1, -line_count);
+                }
+            },
+            None => {
+                if move_up && self.cursor.y > 0 {
+                    content.swap_lines(self.cursor.y - 1, self.cursor.y);
+                } else if move_down && self.cursor.y + 1 < content.len() {
+                    content.swap_lines(self.cursor.y, self.cursor.y + 1);
+                }
+            },
+        }
     }
 
     fn update_cursor_position<T: Content>(&mut self, mut pos: NewCursorPosition, content: &mut T, is_mouse: bool) {

--- a/b4n/ui/presentation/content/edit.rs
+++ b/b4n/ui/presentation/content/edit.rs
@@ -73,25 +73,37 @@ impl EditContext {
         page_start: ContentPosition,
         selection: Option<Selection>,
         area: Rect,
-    ) -> ResponseEvent {
+    ) -> (ResponseEvent, Option<Selection>) {
         if self.app_data.has_binding(event, KeyCommand::EditSelectAll) {
             let last = content.len().saturating_sub(1);
             self.cursor = ContentPosition::new(content.line_size(last), last);
             self.last_key_press = Instant::now();
-            return ResponseEvent::Handled;
+            return (ResponseEvent::Handled, None);
         }
 
         match event {
             TuiEvent::Key(key) => {
-                let pos = if self.app_data.has_key_binding(key, KeyCommand::EditUndo) {
-                    content.undo().map_or((None, None), |pos| (Some(Some(pos.x)), Some(pos.y)))
+                let (pos, restored_selection) = if self.app_data.has_key_binding(key, KeyCommand::EditUndo) {
+                    let Some(result) = content.undo(selection) else {
+                        return (ResponseEvent::NotHandled, None);
+                    };
+                    ((Some(Some(result.0.x)), Some(result.0.y)), result.1)
                 } else if self.app_data.has_key_binding(key, KeyCommand::EditRedo) {
-                    content.redo().map_or((None, None), |pos| (Some(Some(pos.x)), Some(pos.y)))
+                    let Some(result) = content.redo(selection) else {
+                        return (ResponseEvent::NotHandled, None);
+                    };
+                    ((Some(Some(result.0.x)), Some(result.0.y)), result.1)
                 } else {
-                    self.process_key(key, content, selection, area)
+                    (self.process_key(key, content, selection, area), None)
                 };
-                self.update_cursor_position(pos, content, false);
+                if let Some(selection) = &restored_selection {
+                    let pos = get_cursor_pos_for_selection(content, selection.end, selection.is_end_after_start());
+                    self.update_cursor_position((Some(Some(pos.x)), Some(pos.y)), content, false);
+                } else {
+                    self.update_cursor_position(pos, content, false);
+                }
                 self.last_key_press = Instant::now();
+                return (ResponseEvent::Handled, restored_selection);
             },
             TuiEvent::Mouse(mouse) => {
                 if mouse.kind == MouseEventKind::LeftClick {
@@ -102,17 +114,23 @@ impl EditContext {
                         self.cursor = get_cursor_pos_for_selection(content, selection.end, selection.is_end_after_start());
                     }
 
-                    return ResponseEvent::NotHandled;
+                    return (ResponseEvent::NotHandled, None);
                 }
             },
             TuiEvent::Command(command) => {
-                if let Some(pos) = self.process_command(*command, content, selection) {
-                    self.update_cursor_position(pos, content, false);
+                if let Some((pos, restored_selection)) = self.process_command(*command, content, selection) {
+                    if let Some(selection) = &restored_selection {
+                        let pos = get_cursor_pos_for_selection(content, selection.end, selection.is_end_after_start());
+                        self.update_cursor_position((Some(Some(pos.x)), Some(pos.y)), content, false);
+                    } else {
+                        self.update_cursor_position(pos, content, false);
+                    }
+                    return (ResponseEvent::Handled, restored_selection);
                 }
             },
         }
 
-        ResponseEvent::Handled
+        (ResponseEvent::Handled, None)
     }
 
     fn process_command<T: Content>(
@@ -120,19 +138,25 @@ impl EditContext {
         command: KeyCommand,
         content: &mut T,
         selection: Option<Selection>,
-    ) -> Option<NewCursorPosition> {
+    ) -> Option<(NewCursorPosition, Option<Selection>)> {
         match command {
-            KeyCommand::EditUndo => Some(content.undo().map_or((None, None), |pos| (Some(Some(pos.x)), Some(pos.y)))),
-            KeyCommand::EditRedo => Some(content.redo().map_or((None, None), |pos| (Some(Some(pos.x)), Some(pos.y)))),
+            KeyCommand::EditUndo => {
+                let (pos, sel) = content.undo(selection)?;
+                Some(((Some(Some(pos.x)), Some(pos.y)), sel))
+            },
+            KeyCommand::EditRedo => {
+                let (pos, sel) = content.redo(selection)?;
+                Some(((Some(Some(pos.x)), Some(pos.y)), sel))
+            },
             KeyCommand::EditCut => {
                 if let Some(selection) = selection {
                     let start = selection.sorted().0;
-                    content.remove_text(selection);
-                    Some((Some(Some(start.x)), Some(start.y)))
+                    content.remove_text(selection.clone(), Some(selection));
+                    Some(((Some(Some(start.x)), Some(start.y)), None))
                 } else {
                     let range = Selection::from_line_end(content.line_size(self.cursor.y), self.cursor.y);
-                    content.remove_text(range);
-                    Some((None, None))
+                    content.remove_text(range, None);
+                    Some(((None, None), None))
                 }
             },
             _ => None,
@@ -155,7 +179,7 @@ impl EditContext {
             && let Some(selection) = selection
         {
             let start = selection.sorted().0;
-            content.remove_text(selection);
+            content.remove_text(selection.clone(), Some(selection));
 
             if key.code == KeyCode::Backspace || key.code == KeyCode::Delete || is_cut {
                 return (Some(Some(start.x)), Some(start.y));
@@ -167,7 +191,7 @@ impl EditContext {
         let is_del_line = self.app_data.has_key_binding(key, KeyCommand::EditDeleteLine);
         if is_cut || is_del_line {
             let range = Selection::from_line_end(content.line_size(self.cursor.y), self.cursor.y);
-            content.remove_text(range);
+            content.remove_text(range, None);
             return (None, None);
         }
 
@@ -262,19 +286,14 @@ impl EditContext {
         }
 
         if let Some(selection) = &selection {
-            let mut cursor = selection.end;
-            if cursor.x >= content.line_size(cursor.y) {
-                cursor.x = 0;
-                cursor.y += 1;
-            }
-
+            let cursor = get_cursor_pos_for_selection(content, selection.end, selection.is_end_after_start());
             let sorted = selection.sorted();
             let line_count = i32::try_from(sorted.1.y - sorted.0.y + 1).unwrap_or_default();
             if move_up && sorted.0.y > 0 {
-                content.move_line(sorted.0.y - 1, line_count);
+                content.move_line(sorted.0.y - 1, line_count, Some(selection.clone()));
                 return Some((Some(Some(cursor.x)), Some(cursor.y.saturating_sub(1))));
             } else if move_down && sorted.1.y + 1 < content.len() {
-                content.move_line(sorted.1.y + 1, -line_count);
+                content.move_line(sorted.1.y + 1, -line_count, Some(selection.clone()));
                 if cursor.y + 1 < content.len() {
                     return Some((Some(Some(cursor.x)), Some(cursor.y + 1)));
                 } else {
@@ -283,10 +302,10 @@ impl EditContext {
             }
         } else {
             if move_up && self.cursor.y > 0 {
-                content.swap_lines(self.cursor.y - 1, self.cursor.y);
+                content.swap_lines(self.cursor.y - 1, self.cursor.y, None);
                 return Some((Some(Some(self.cursor.x)), Some(self.cursor.y.saturating_sub(1))));
             } else if move_down && self.cursor.y + 1 < content.len() {
-                content.swap_lines(self.cursor.y, self.cursor.y + 1);
+                content.swap_lines(self.cursor.y, self.cursor.y + 1, None);
                 return Some((Some(Some(self.cursor.x)), Some(self.cursor.y + 1)));
             }
         }

--- a/b4n/ui/presentation/content/edit.rs
+++ b/b4n/ui/presentation/content/edit.rs
@@ -286,9 +286,16 @@ impl EditContext {
         }
 
         if let Some(selection) = &selection {
-            let cursor = get_cursor_pos_for_selection(content, selection.end, selection.is_end_after_start());
             let sorted = selection.sorted();
             let line_count = i32::try_from(sorted.1.y - sorted.0.y + 1).unwrap_or_default();
+            let mut cursor = selection.end;
+            if cursor.x >= content.line_size(cursor.y) {
+                cursor.x = 0;
+                cursor.y += 1;
+            } else {
+                cursor.x += 1;
+            }
+
             if move_up && sorted.0.y > 0 {
                 content.move_line(sorted.0.y - 1, line_count, Some(selection.clone()));
                 return Some((Some(Some(cursor.x)), Some(cursor.y.saturating_sub(1))));

--- a/b4n/ui/presentation/content/edit.rs
+++ b/b4n/ui/presentation/content/edit.rs
@@ -146,7 +146,9 @@ impl EditContext {
         selection: Option<Selection>,
         area: Rect,
     ) -> NewCursorPosition {
-        self.handle_lines_move(key, content, &selection);
+        if let Some(pos) = self.handle_lines_move(key, content, &selection) {
+            return pos;
+        }
 
         let is_cut = self.app_data.has_key_binding(key, KeyCommand::EditCut);
         if (is_hiding_selection_key(key) || is_cut)
@@ -246,12 +248,17 @@ impl EditContext {
         (None, None)
     }
 
-    fn handle_lines_move<T: Content>(&mut self, key: &KeyCombination, content: &mut T, selection: &Option<Selection>) {
+    fn handle_lines_move<T: Content>(
+        &mut self,
+        key: &KeyCombination,
+        content: &mut T,
+        selection: &Option<Selection>,
+    ) -> Option<NewCursorPosition> {
         let move_up = self.app_data.has_key_binding(key, KeyCommand::EditMoveUp);
         let move_down = self.app_data.has_key_binding(key, KeyCommand::EditMoveDown);
 
         if !move_up && !move_down {
-            return;
+            return None;
         }
 
         match selection.as_ref().map(Selection::sorted) {
@@ -259,18 +266,24 @@ impl EditContext {
                 let line_count = i32::try_from(sorted.1.y - sorted.0.y + 1).unwrap_or_default();
                 if move_up && sorted.0.y > 0 {
                     content.move_line(sorted.0.y - 1, line_count);
+                    return Some((Some(Some(self.cursor.x)), Some(self.cursor.y.saturating_sub(1))));
                 } else if move_down && sorted.1.y + 1 < content.len() {
                     content.move_line(sorted.1.y + 1, -line_count);
+                    return Some((Some(Some(self.cursor.x)), Some(self.cursor.y + 1)));
                 }
             },
             None => {
                 if move_up && self.cursor.y > 0 {
                     content.swap_lines(self.cursor.y - 1, self.cursor.y);
+                    return Some((Some(Some(self.cursor.x)), Some(self.cursor.y.saturating_sub(1))));
                 } else if move_down && self.cursor.y + 1 < content.len() {
                     content.swap_lines(self.cursor.y, self.cursor.y + 1);
+                    return Some((Some(Some(self.cursor.x)), Some(self.cursor.y + 1)));
                 }
             },
         }
+
+        Some((None, None))
     }
 
     fn update_cursor_position<T: Content>(&mut self, mut pos: NewCursorPosition, content: &mut T, is_mouse: bool) {

--- a/b4n/ui/presentation/content/mod.rs
+++ b/b4n/ui/presentation/content/mod.rs
@@ -95,29 +95,36 @@ pub trait Content {
     }
 
     /// Removes the specified `range` from the content.
-    fn remove_text(&mut self, range: Selection) {
+    fn remove_text(&mut self, range: Selection, selection: Option<Selection>) {
         let _ = range;
+        let _ = selection;
     }
 
     /// Swaps two lines in the content.
-    fn swap_lines(&mut self, first_line: usize, second_line: usize) {
+    fn swap_lines(&mut self, first_line: usize, second_line: usize, selection: Option<Selection>) {
         let _ = first_line;
         let _ = second_line;
+        let _ = selection;
     }
 
     /// Moves line by the specified offset.
-    fn move_line(&mut self, line: usize, offset: i32) {
+    fn move_line(&mut self, line: usize, offset: i32, selection: Option<Selection>) {
         let _ = line;
         let _ = offset;
+        let _ = selection;
     }
 
-    /// Reverts most recent changes done in edit mode.
-    fn undo(&mut self) -> Option<ContentPosition> {
+    /// Reverts most recent changes done in edit mode.\
+    /// Returns cursor position and the selection that was active before the change.
+    fn undo(&mut self, selection: Option<Selection>) -> Option<(ContentPosition, Option<Selection>)> {
+        let _ = selection;
         None
     }
 
-    /// Re-applies an action that was previously undone.
-    fn redo(&mut self) -> Option<ContentPosition> {
+    /// Re-applies an action that was previously undone.\
+    /// Returns cursor position and the selection that was active before the change.
+    fn redo(&mut self, selection: Option<Selection>) -> Option<(ContentPosition, Option<Selection>)> {
+        let _ = selection;
         None
     }
 

--- a/b4n/ui/presentation/content/mod.rs
+++ b/b4n/ui/presentation/content/mod.rs
@@ -105,6 +105,12 @@ pub trait Content {
         let _ = second_line;
     }
 
+    /// Moves line by the specified offset.
+    fn move_line(&mut self, line: usize, offset: i32) {
+        let _ = line;
+        let _ = offset;
+    }
+
     /// Reverts most recent changes done in edit mode.
     fn undo(&mut self) -> Option<ContentPosition> {
         None

--- a/b4n/ui/presentation/content/search.rs
+++ b/b4n/ui/presentation/content/search.rs
@@ -39,6 +39,15 @@ impl ContentPosition {
     pub fn sub_y(&mut self, value: usize) {
         self.y = self.y.saturating_sub(value);
     }
+
+    // Moves content vertically by specified `delta`.
+    pub fn offset_y(&mut self, delta: isize) {
+        if delta > 0 {
+            self.y = self.y.saturating_add(delta as usize);
+        } else {
+            self.y = self.y.saturating_sub(delta.unsigned_abs());
+        }
+    }
 }
 
 #[derive(Default)]

--- a/b4n/ui/presentation/content/select.rs
+++ b/b4n/ui/presentation/content/select.rs
@@ -85,6 +85,28 @@ impl SelectContext {
         self.init = None;
     }
 
+    /// Moves selection vertically by specified `delta`.
+    pub fn move_selection_vertical(&mut self, delta: isize, content_len: usize) {
+        let (Some(start), Some(end)) = (&mut self.start, &mut self.end) else {
+            return;
+        };
+
+        let content_len = content_len.saturating_sub(1);
+        let would_underflow = delta < 0 && (start.y == 0 || end.y == 0);
+        let would_overflow = delta > 0 && (start.y >= content_len || end.y >= content_len);
+
+        if would_underflow || would_overflow {
+            return;
+        }
+
+        start.offset_y(delta);
+        end.offset_y(delta);
+
+        if let Some(init) = &mut self.init {
+            init.offset_y(delta);
+        }
+    }
+
     /// Clears the current selection start (if end is not set) or adjusts the `init` of the selection
     /// to match situation when cursor is after selection start.
     pub fn adjust_selection(&mut self) {
@@ -149,6 +171,10 @@ impl SelectContext {
                 self.start = Some(decrement_cursor_x(init, content));
                 self.end = Some(cursor);
             }
+        } else if self.app_data.has_key_binding(key, KeyCommand::EditMoveUp) {
+            self.move_selection_vertical(-1, content.len());
+        } else if self.app_data.has_key_binding(key, KeyCommand::EditMoveDown) {
+            self.move_selection_vertical(1, content.len());
         } else if !self.app_data.has_key_binding(key, KeyCommand::EditSelectAll) {
             self.clear_selection();
         }

--- a/b4n/ui/presentation/content/viewer.rs
+++ b/b4n/ui/presentation/content/viewer.rs
@@ -355,7 +355,7 @@ impl<T: Content> ContentViewer<T> {
         if let Some(content) = &mut self.content {
             if let Some(range) = self.select.get_selection() {
                 self.edit.cursor = range.sorted().0;
-                content.remove_text(range);
+                content.remove_text(range.clone(), Some(range));
             }
 
             self.select.clear_selection();
@@ -432,11 +432,15 @@ impl<T: Content> ContentViewer<T> {
                 .process_event(event, content, &mut self.page_start, cursor, self.page_area);
 
             if self.edit.is_enabled {
-                let response =
+                let (response, restored_selection) =
                     self.edit
                         .process_event(event, content, self.page_start, self.select.get_selection(), self.page_area);
                 if response != ResponseEvent::NotHandled {
-                    self.select.process_event_final(event, content, self.edit.cursor);
+                    if let Some(selection) = restored_selection {
+                        self.select.update_selection(Some(selection));
+                    } else {
+                        self.select.process_event_final(event, content, self.edit.cursor);
+                    }
                     let (y, x) = (self.edit.cursor.y, self.edit.cursor.x);
                     self.scroll_to(y, x, 1);
                     return response;

--- a/b4n/ui/views/yaml/content.rs
+++ b/b4n/ui/views/yaml/content.rs
@@ -405,6 +405,36 @@ impl Content for YamlContent {
         self.undo.push(Undo::swap(first_line, second_line));
     }
 
+    fn move_line(&mut self, line: usize, offset: i32) {
+        if offset == 0 || line >= self.plain.len() {
+            return;
+        }
+
+        let target = if offset < 0 {
+            line.saturating_sub(offset.unsigned_abs() as usize)
+        } else {
+            (line + offset as usize).min(self.plain.len() - 1)
+        };
+
+        if target == line {
+            return;
+        }
+
+        self.redo.clear();
+
+        if target < line {
+            for i in (target..line).rev() {
+                self.swap_lines_internal(i, i + 1);
+                self.undo.push(Undo::swap(i, i + 1));
+            }
+        } else {
+            for i in line..target {
+                self.swap_lines_internal(i, i + 1);
+                self.undo.push(Undo::swap(i, i + 1));
+            }
+        }
+    }
+
     fn undo(&mut self) -> Option<ContentPosition> {
         let mut actions = pop_recent_group(&mut self.undo, Duration::from_millis(300));
         if actions.is_empty() {

--- a/b4n/ui/views/yaml/content.rs
+++ b/b4n/ui/views/yaml/content.rs
@@ -394,6 +394,12 @@ impl Content for YamlContent {
     }
 
     fn remove_text(&mut self, range: Selection) {
+        let sorted = range.sorted();
+        let range = if sorted.1.y + 1 == self.len() && sorted.1.x == self.line_size(sorted.1.y) {
+            Selection::new(sorted.0, ContentPosition::new(sorted.1.x.saturating_sub(1), sorted.1.y))
+        } else {
+            range
+        };
         let removed = self.remove_text_internal(&range);
         self.redo.clear();
         self.undo.push(Undo::cut(&range, removed));

--- a/b4n/ui/views/yaml/content.rs
+++ b/b4n/ui/views/yaml/content.rs
@@ -214,7 +214,7 @@ impl YamlContent {
 
     fn track_remove(&mut self, pos: ContentPosition, ch: char, track: bool) -> ContentPosition {
         if track {
-            self.undo.push(Undo::remove(pos, ch));
+            self.undo.push(Undo::remove(pos, ch, None));
         }
 
         pos
@@ -376,7 +376,7 @@ impl Content for YamlContent {
 
     fn insert_char(&mut self, position: ContentPosition, ch: char) {
         self.redo.clear();
-        self.undo.push(Undo::insert(position, ch));
+        self.undo.push(Undo::insert(position, ch, None));
         self.insert_char_internal(position, ch);
     }
 
@@ -384,7 +384,7 @@ impl Content for YamlContent {
         self.redo.clear();
         let end = self.insert_text_internal(position, text);
         self.undo
-            .push(Undo::paste(&Selection::new(position, self.move_position_left(end))));
+            .push(Undo::paste(&Selection::new(position, self.move_position_left(end)), None));
         end
     }
 
@@ -393,7 +393,7 @@ impl Content for YamlContent {
         self.remove_char_internal(position, is_backspace, true)
     }
 
-    fn remove_text(&mut self, range: Selection) {
+    fn remove_text(&mut self, range: Selection, selection: Option<Selection>) {
         let sorted = range.sorted();
         let range = if sorted.1.y + 1 == self.len() && sorted.1.x == self.line_size(sorted.1.y) {
             Selection::new(sorted.0, ContentPosition::new(sorted.1.x.saturating_sub(1), sorted.1.y))
@@ -402,16 +402,16 @@ impl Content for YamlContent {
         };
         let removed = self.remove_text_internal(&range);
         self.redo.clear();
-        self.undo.push(Undo::cut(&range, removed));
+        self.undo.push(Undo::cut(&range, removed, selection));
     }
 
-    fn swap_lines(&mut self, first_line: usize, second_line: usize) {
+    fn swap_lines(&mut self, first_line: usize, second_line: usize, selection: Option<Selection>) {
         self.swap_lines_internal(first_line, second_line);
         self.redo.clear();
-        self.undo.push(Undo::swap(first_line, second_line));
+        self.undo.push(Undo::swap(first_line, second_line, selection));
     }
 
-    fn move_line(&mut self, line: usize, offset: i32) {
+    fn move_line(&mut self, line: usize, offset: i32, selection: Option<Selection>) {
         if offset == 0 || line >= self.plain.len() {
             return;
         }
@@ -431,35 +431,37 @@ impl Content for YamlContent {
         if target < line {
             for i in (target..line).rev() {
                 self.swap_lines_internal(i, i + 1);
-                self.undo.push(Undo::swap(i, i + 1));
+                self.undo.push(Undo::swap(i, i + 1, selection.clone()));
             }
         } else {
             for i in line..target {
                 self.swap_lines_internal(i, i + 1);
-                self.undo.push(Undo::swap(i, i + 1));
+                self.undo.push(Undo::swap(i, i + 1, selection.clone()));
             }
         }
     }
 
-    fn undo(&mut self) -> Option<ContentPosition> {
+    fn undo(&mut self, selection: Option<Selection>) -> Option<(ContentPosition, Option<Selection>)> {
         let mut actions = pop_recent_group(&mut self.undo, Duration::from_millis(300));
         if actions.is_empty() {
             return None;
         }
 
-        let mut result = None;
+        let restored_selection = actions.last().and_then(|u| u.selection.clone());
+
+        let mut cursor = actions[0].pos;
         for action in &mut actions {
             match action.mode {
                 UndoMode::Insert => {
                     self.remove_char_internal(action.pos, false, false);
-                    result = Some(action.pos);
+                    cursor = action.pos;
                 },
                 UndoMode::Remove => {
                     self.insert_char_internal(action.pos, action.ch);
                     if action.ch == '\n' {
-                        result = Some(ContentPosition::new(0, action.pos.y.saturating_add(1)));
+                        cursor = ContentPosition::new(0, action.pos.y.saturating_add(1));
                     } else {
-                        result = Some(ContentPosition::new(action.pos.x.saturating_add(1), action.pos.y));
+                        cursor = ContentPosition::new(action.pos.x.saturating_add(1), action.pos.y);
                     }
                 },
                 UndoMode::Cut => {
@@ -467,7 +469,7 @@ impl Content for YamlContent {
                         let text = action.text.take();
                         if let Some(text) = text {
                             self.insert_text_internal(action.pos, text);
-                            result = Some(ContentPosition { x: end.x + 1, y: end.y });
+                            cursor = ContentPosition { x: end.x + 1, y: end.y };
                         }
                     }
                 },
@@ -475,46 +477,52 @@ impl Content for YamlContent {
                     if let Some(end) = action.end {
                         let range = Selection::new(action.pos, end);
                         action.text = Some(self.remove_text_internal(&range));
-                        result = Some(action.pos);
+                        cursor = action.pos;
                     }
                 },
                 UndoMode::Swap => {
                     if let Some(end) = action.end {
                         self.swap_lines_internal(action.pos.y, end.y);
-                        result = Some(end);
+                        cursor = end;
                     }
                 },
             }
         }
 
+        actions[0].selection = selection;
         self.redo.push(actions);
-        result
+        Some((cursor, restored_selection))
     }
 
-    fn redo(&mut self) -> Option<ContentPosition> {
+    fn redo(&mut self, selection: Option<Selection>) -> Option<(ContentPosition, Option<Selection>)> {
         let mut actions = self.redo.pop()?;
-        let mut result = None;
+        if actions.is_empty() {
+            return None;
+        }
 
+        let restored_selection = actions.first().and_then(|u| u.selection.clone());
         actions.reverse();
+
+        let mut cursor = actions[0].pos;
         for action in &mut actions {
             match action.mode {
                 UndoMode::Insert => {
                     self.insert_char_internal(action.pos, action.ch);
                     if action.ch == '\n' {
-                        result = Some(ContentPosition::new(0, action.pos.y.saturating_add(1)));
+                        cursor = ContentPosition::new(0, action.pos.y.saturating_add(1));
                     } else {
-                        result = Some(ContentPosition::new(action.pos.x.saturating_add(1), action.pos.y));
+                        cursor = ContentPosition::new(action.pos.x.saturating_add(1), action.pos.y);
                     }
                 },
                 UndoMode::Remove => {
                     self.remove_char_internal(action.pos, false, false);
-                    result = Some(action.pos);
+                    cursor = action.pos;
                 },
                 UndoMode::Cut => {
                     if let Some(end) = action.end {
                         let range = Selection::new(action.pos, end);
                         action.text = Some(self.remove_text_internal(&range));
-                        result = Some(action.pos);
+                        cursor = action.pos;
                     }
                 },
                 UndoMode::Paste => {
@@ -522,21 +530,22 @@ impl Content for YamlContent {
                         let text = action.text.take();
                         if let Some(text) = text {
                             self.insert_text_internal(action.pos, text);
-                            result = Some(ContentPosition { x: end.x + 1, y: end.y });
+                            cursor = ContentPosition { x: end.x + 1, y: end.y };
                         }
                     }
                 },
                 UndoMode::Swap => {
                     if let Some(end) = action.end {
                         self.swap_lines_internal(action.pos.y, end.y);
-                        result = Some(end);
+                        cursor = end;
                     }
                 },
             }
         }
 
+        actions[0].selection = selection;
         self.undo.extend(actions);
-        result
+        Some((cursor, restored_selection))
     }
 
     fn process_tick(&mut self) -> ResponseEvent {

--- a/b4n/ui/views/yaml/undo.rs
+++ b/b4n/ui/views/yaml/undo.rs
@@ -21,11 +21,12 @@ pub struct Undo {
     pub text: Option<Vec<String>>,
     pub mode: UndoMode,
     pub when: Instant,
+    pub selection: Option<Selection>,
 }
 
 impl Undo {
     /// Creates a new undo/redo entry representing an inserted character.
-    pub fn insert(pos: ContentPosition, ch: char) -> Self {
+    pub fn insert(pos: ContentPosition, ch: char, selection: Option<Selection>) -> Self {
         Self {
             pos,
             end: None,
@@ -33,11 +34,12 @@ impl Undo {
             text: None,
             mode: UndoMode::Insert,
             when: Instant::now(),
+            selection,
         }
     }
 
     /// Creates a new undo/redo entry representing a removed character.
-    pub fn remove(pos: ContentPosition, ch: char) -> Self {
+    pub fn remove(pos: ContentPosition, ch: char, selection: Option<Selection>) -> Self {
         Self {
             pos,
             end: None,
@@ -45,11 +47,12 @@ impl Undo {
             text: None,
             mode: UndoMode::Remove,
             when: Instant::now(),
+            selection,
         }
     }
 
     /// Creates a new undo/redo entry representing a cut (range removal).
-    pub fn cut(range: &Selection, removed_text: Vec<String>) -> Self {
+    pub fn cut(range: &Selection, removed_text: Vec<String>, selection: Option<Selection>) -> Self {
         let (start, end) = range.sorted();
         Self {
             pos: start,
@@ -58,11 +61,12 @@ impl Undo {
             text: Some(removed_text),
             mode: UndoMode::Cut,
             when: Instant::now(),
+            selection,
         }
     }
 
     /// Creates a new undo/redo entry representing a paste (range insertion).
-    pub fn paste(range: &Selection) -> Self {
+    pub fn paste(range: &Selection, selection: Option<Selection>) -> Self {
         let (start, end) = range.sorted();
         Self {
             pos: start,
@@ -71,11 +75,12 @@ impl Undo {
             text: None,
             mode: UndoMode::Paste,
             when: Instant::now(),
+            selection,
         }
     }
 
     /// Creates a new undo/redo entry representing a lines swap.
-    pub fn swap(first_line: usize, second_line: usize) -> Self {
+    pub fn swap(first_line: usize, second_line: usize, selection: Option<Selection>) -> Self {
         Self {
             pos: ContentPosition::new(0, first_line),
             end: Some(ContentPosition::new(0, second_line)),
@@ -83,6 +88,7 @@ impl Undo {
             text: None,
             mode: UndoMode::Swap,
             when: Instant::now(),
+            selection,
         }
     }
 }


### PR DESCRIPTION
This PR allows to move selected text using `Alt+↑` and `Alt+↓`.